### PR TITLE
Supply revision numbers for all builds

### DIFF
--- a/pkg/archive/deb.go
+++ b/pkg/archive/deb.go
@@ -83,7 +83,7 @@ func (d *debArchive) Package(client *dagger.Client, c *dagger.Container, project
 	dir := client.Directory()
 	rootDir := "/package"
 
-	version := fmt.Sprintf("%s+azure-%su%d", project.Tag, debDistroMap[project.Distro], 1)
+	version := fmt.Sprintf("%s+azure-%su%s", project.Tag, debDistroMap[project.Distro], project.Revision)
 	c = c.WithDirectory(rootDir, dir)
 	c = d.moveStaticFiles(c, rootDir)
 	c = d.withControlFile(c, version, project)

--- a/pkg/archive/rpm.go
+++ b/pkg/archive/rpm.go
@@ -73,13 +73,15 @@ func (r *rpmArchive) Package(client *dagger.Client, c *dagger.Container, project
 	pkgDir := c.Directory(rootDir)
 	fpm := fpmContainer(client, r.mirrorPrefix)
 
-	filename := fmt.Sprintf("%s-%s+azure-%d.%s.%s.rpm", project.Pkg, project.Tag, 1, rpmDistroMap[project.Distro], rpmArchMap[project.Arch])
+	filename := fmt.Sprintf("%s-%s+azure-%s.%s.%s.rpm", project.Pkg, project.Tag, project.Revision, rpmDistroMap[project.Distro], rpmArchMap[project.Arch])
 
 	fpmArgs := []string{"fpm",
 		"-s", "dir",
 		"-t", "rpm",
 		"-n", project.Pkg,
-		"--version", project.Tag + "azure",
+		"--version", project.Tag + "+azure",
+		"--iteration", project.Revision,
+		"--rpm-dist", rpmDistroMap[project.Distro],
 		"--architecture", project.Arch,
 		"--description", r.a.Description,
 		"--url", r.a.Webpage,

--- a/targets/target.go
+++ b/targets/target.go
@@ -240,6 +240,7 @@ func (t *Target) Make(project *build.Spec) *dagger.Directory {
 		WithWorkdir("/build").
 		WithExec(t.installDepsCmd()).
 		WithMountedFile("/usr/bin/go-md2man", md2man).
+		WithEnvVariable("REVISION", project.Revision).
 		WithEnvVariable("VERSION", project.Tag).
 		WithEnvVariable("COMMIT", project.Commit).
 		// WithEnvVariable("SOURCE_DATE_EPOCH", commitTime).


### PR DESCRIPTION
The packages will be built with REVISION in the environment. This may not be enough to get the values linked in to the binaries where necessary.

In addition, the values are propagated to the packages by the correct filename and (for rpm) by setting `--iteration` and `--rpm-dist` on the fpm invocation.

resolves #3 

check each .spec file for rpm builds to ensure the revision gets to where it needs to
- [x] cli
- [x] containerd
- [x] buildx
- [x] engine
- [x] compose
- [x] runc
- [x] init N/A, package did not exist before
- [x] shim (REVISION not consumed anywhere)

check each rules file for deb builds:
- [x] cli
- [x] containerd
- [x] buildx
- [x] engine
- [x] compose
- [x] runc
- [x] init N/A, package did not exist before
- [x] shim (REVISION not consumed anywhere)