### PR TITLE
Install updated binutils for rhel8 builds

### DIFF
--- a/moby-containerd-shim-systemd/rpm.mk
+++ b/moby-containerd-shim-systemd/rpm.mk
@@ -3,4 +3,8 @@
 export GOGC=off
 
 rpm:
-	cd src && make build
+	if [ -n "$$GCC_VERSION" ] && [ -n "$$GCC_ENV_VILE" ]; then\
+		source "$$GCC_ENV_VILE"; \
+		fi; \
+		cd src && make build
+

--- a/targets/rhel8.go
+++ b/targets/rhel8.go
@@ -17,8 +17,11 @@ func Rhel8(ctx context.Context, client *dagger.Client, platform dagger.Platform)
 		WithExec([]string{"bash", "-c", `
         yum -y install dnf-plugins-core || true
         yum config-manager --set-enabled powertools || true
+        yum install -y gcc-toolset-12-binutils
         `})
 	c = YumInstall(c, BaseRPMPackages...)
+	c = c.WithEnvVariable("GCC_VERSION", "12").
+		WithEnvVariable("GCC_ENV_VILE", "/opt/rh/gcc-toolset-12/enable")
 
 	buildPlatform, err := client.DefaultPlatform(ctx)
 	if err != nil {


### PR DESCRIPTION
This involves installing an additional binutils toolchain. In the rpm makefile for rhel8, some information has to be sourced into the environment in order for the changes to fix the build.

Partially resolves #4 .

See [additional toolsets for development](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/developing_c_and_cpp_applications_in_rhel_8/additional-toolsets-for-development_developing-applications) for more information.