### PR TITLE
Test without go installation

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -58,7 +58,6 @@ stages:
         timeoutInMinutes: 240
         steps:
           - bash: |
-              cd $(Pipeline.Workspace)/packaging
               set -x
               printf '
                 {


### PR DESCRIPTION
ADO build agents have been upgraded to go1.20.3, making its installation unnecessary.