### PR TITLE
Fix windows build container

### DIFF
--- a/targets/windows.go
+++ b/targets/windows.go
@@ -14,14 +14,15 @@ var (
 
 func Windows(ctx context.Context, client *dagger.Client, platform dagger.Platform) (*Target, error) {
 	client = client.Pipeline("windows/" + string(platform))
-	c := client.Container(dagger.ContainerOpts{Platform: platform}).From(WindowsRef)
-	c = apt.Install(c, client.CacheVolume("bullseye-apt-cache"), client.CacheVolume("bullseye-apt-lib-cache"), BaseWinPackages...)
-	c = c.WithEnvVariable("GOOS", "windows")
 
 	buildPlatform, err := client.DefaultPlatform(ctx)
 	if err != nil {
 		return nil, err
 	}
+
+	c := client.Container(dagger.ContainerOpts{Platform: buildPlatform}).From(WindowsRef)
+	c = apt.Install(c, client.CacheVolume("bullseye-apt-cache"), client.CacheVolume("bullseye-apt-lib-cache"), BaseWinPackages...)
+	c = c.WithEnvVariable("GOOS", "windows")
 
 	t := &Target{client: client, c: c, platform: platform, name: "windows", pkgKind: "win", buildPlatform: buildPlatform}
 	t, err = t.WithPlatformEnvs().InstallGo(ctx)


### PR DESCRIPTION
The platform passed in to the `Windows` target function ends up being "windows/\<arch\>", which when used as the container platform results in a manifest retrieval error; these images aren't available for windows.