### PR TITLE
Fix qemu kernel install

### DIFF
--- a/testutil/qemu.go
+++ b/testutil/qemu.go
@@ -15,7 +15,7 @@ func NewQemuImg(ctx context.Context, client *dagger.Client) *dagger.Container {
 		ctr,
 		client.CacheVolume(targets.JammyAptCacheKey),
 		client.CacheVolume(targets.JammyAptLibCacheKey),
-		"qemu", "qemu-system", "qemu-utils", "openssh-client", "iptables", "linux-image-5.15.0-1031-kvm", "linux-modules-5.15.0-1031-kvm")
+		"qemu", "qemu-system", "qemu-utils", "openssh-client", "iptables", "linux-image-5.15.*-kvm", "linux-modules-5.15.*-kvm")
 }
 
 // QcowFromDir creates a qcow2 image from a dagger directory.


### PR DESCRIPTION
This kernel is used inside the test VM.
Before this change the install is broken due to updated versions of these pacakges being released and Canonical removes the older packages from the repo. Now it just installs what's there.