### PR TITLE
runc: set version on runc binary

### DIFF
--- a/moby-runc/deb.mk
+++ b/moby-runc/deb.mk
@@ -2,6 +2,7 @@ deb: runc man/man8
 
 runc:
 	cd src && \
+	echo $(VERSION)-$(REVISION) > VERSION && \
 	$(MAKE) runc BUILDTAGS='seccomp'
 
 man/man8:

--- a/moby-runc/rpm.mk
+++ b/moby-runc/rpm.mk
@@ -3,6 +3,7 @@ rpm: runc man/man8
 
 runc:
 	cd src && \
+	echo $(VERSION)-$(REVISION) > VERSION && \
 	$(MAKE) runc BUILDTAGS='seccomp'
 
 man/man8:


### PR DESCRIPTION
This was not getting set before because the runc build scripts always read from the `VERSION` file in the repo source.

Closes #52