### PR TITLE
Various test fixes simplifications

### DIFF
--- a/distros_test.go
+++ b/distros_test.go
@@ -24,7 +24,7 @@ const (
 	mariner2 = "mariner2"
 )
 
-var distros = map[string]func(context.Context, *testing.T, *dagger.Client) *dagger.Container{
+var distros = map[string]func(context.Context, *testing.T, *dagger.Client) (ctr *dagger.Container, pkgInstaller *dagger.File){
 	jammy:    Jammy,
 	focal:    Focal,
 	bionic:   Bionic,
@@ -46,111 +46,111 @@ var (
 	mariner2Install string
 )
 
-func Jammy(ctx context.Context, t *testing.T, client *dagger.Client) *dagger.Container {
+func Jammy(ctx context.Context, t *testing.T, client *dagger.Client) (*dagger.Container, *dagger.File) {
 	deb := client.HTTP("https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb")
 
 	c := client.Container().From(targets.JammyRef)
+
 	return apt.Install(c, client.CacheVolume(targets.JammyAptCacheKey), client.CacheVolume(targets.JammyAptLibCacheKey),
-		"systemd", "strace", "ssh", "udev", "iptables", "jq",
-	).
-		WithExec([]string{"systemctl", "enable", "ssh"}).
-		WithExec([]string{"update-alternatives", "--set", "iptables", "/usr/sbin/iptables-legacy"}).
-		WithMountedFile("/tmp/packages-microsoft-prod.deb", deb).
-		WithExec([]string{"/usr/bin/dpkg", "-i", "/tmp/packages-microsoft-prod.deb"}).
-		WithNewFile("/opt/moby/install.sh", dagger.ContainerWithNewFileOpts{Contents: debInstall, Permissions: 0744})
+			"systemd", "strace", "ssh", "udev", "iptables", "jq",
+		).
+			WithExec([]string{"systemctl", "enable", "ssh"}).
+			WithExec([]string{"update-alternatives", "--set", "iptables", "/usr/sbin/iptables-legacy"}).
+			WithMountedFile("/tmp/packages-microsoft-prod.deb", deb).
+			WithExec([]string{"/usr/bin/dpkg", "-i", "/tmp/packages-microsoft-prod.deb"}),
+		client.Container().Rootfs().WithNewFile("install.sh", debInstall, dagger.DirectoryWithNewFileOpts{Permissions: 0744}).File("install.sh")
 }
 
-func Focal(ctx context.Context, t *testing.T, client *dagger.Client) *dagger.Container {
+func Focal(ctx context.Context, t *testing.T, client *dagger.Client) (*dagger.Container, *dagger.File) {
 	deb := client.HTTP("https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb")
 
 	c := client.Container().From(targets.FocalRef)
 	return apt.Install(c, client.CacheVolume(targets.FocalAptCacheKey), client.CacheVolume(targets.FocalAptLibCacheKey),
-		"systemd", "strace", "ssh", "udev", "iptables", "jq",
-	).
-		WithExec([]string{"systemctl", "enable", "ssh"}).
-		WithExec([]string{"update-alternatives", "--set", "iptables", "/usr/sbin/iptables-legacy"}).
-		WithMountedFile("/tmp/packages-microsoft-prod.deb", deb).
-		WithExec([]string{"/usr/bin/dpkg", "-i", "/tmp/packages-microsoft-prod.deb"}).
-		WithNewFile("/opt/moby/install.sh", dagger.ContainerWithNewFileOpts{Contents: debInstall, Permissions: 0744})
+			"systemd", "strace", "ssh", "udev", "iptables", "jq",
+		).
+			WithExec([]string{"systemctl", "enable", "ssh"}).
+			WithExec([]string{"update-alternatives", "--set", "iptables", "/usr/sbin/iptables-legacy"}).
+			WithMountedFile("/tmp/packages-microsoft-prod.deb", deb).
+			WithExec([]string{"/usr/bin/dpkg", "-i", "/tmp/packages-microsoft-prod.deb"}),
+		client.Container().Rootfs().WithNewFile("install.sh", debInstall, dagger.DirectoryWithNewFileOpts{Permissions: 0744}).File("install.sh")
 }
 
-func Bionic(ctx context.Context, t *testing.T, client *dagger.Client) *dagger.Container {
+func Bionic(ctx context.Context, t *testing.T, client *dagger.Client) (*dagger.Container, *dagger.File) {
 	deb := client.HTTP("https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb")
 
 	c := client.Container().From(targets.BionicRef)
 	return apt.Install(c, client.CacheVolume(targets.BionicAptCacheKey), client.CacheVolume(targets.BionicAptLibCacheKey),
-		"systemd", "strace", "ssh", "udev", "iptables", "jq",
-	).
-		WithExec([]string{"systemctl", "enable", "ssh"}).
-		WithExec([]string{"update-alternatives", "--set", "iptables", "/usr/sbin/iptables-legacy"}).
-		WithMountedFile("/tmp/packages-microsoft-prod.deb", deb).
-		WithExec([]string{"/usr/bin/dpkg", "-i", "/tmp/packages-microsoft-prod.deb"}).
-		WithNewFile("/opt/moby/install.sh", dagger.ContainerWithNewFileOpts{Contents: debInstall, Permissions: 0744})
+			"systemd", "strace", "ssh", "udev", "iptables", "jq",
+		).
+			WithExec([]string{"systemctl", "enable", "ssh"}).
+			WithExec([]string{"update-alternatives", "--set", "iptables", "/usr/sbin/iptables-legacy"}).
+			WithMountedFile("/tmp/packages-microsoft-prod.deb", deb).
+			WithExec([]string{"/usr/bin/dpkg", "-i", "/tmp/packages-microsoft-prod.deb"}),
+		client.Container().Rootfs().WithNewFile("install.sh", debInstall, dagger.DirectoryWithNewFileOpts{Permissions: 0744}).File("install.sh")
 }
 
-func Bullseye(ctx context.Context, t *testing.T, client *dagger.Client) *dagger.Container {
+func Bullseye(ctx context.Context, t *testing.T, client *dagger.Client) (*dagger.Container, *dagger.File) {
 	deb := client.HTTP("https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb")
 
 	c := client.Container().From(targets.BullseyeRef)
 	return apt.Install(c, client.CacheVolume(targets.BullseyeAptCacheKey), client.CacheVolume(targets.BullseyeAptLibCacheKey),
-		"systemd", "strace", "ssh", "udev", "iptables", "jq",
-	).
-		WithExec([]string{"systemctl", "enable", "ssh"}).
-		WithExec([]string{"update-alternatives", "--set", "iptables", "/usr/sbin/iptables-legacy"}).
-		WithMountedFile("/tmp/packages-microsoft-prod.deb", deb).
-		WithExec([]string{"/usr/bin/dpkg", "-i", "/tmp/packages-microsoft-prod.deb"}).
-		WithNewFile("/opt/moby/install.sh", dagger.ContainerWithNewFileOpts{Contents: debInstall, Permissions: 0744})
+			"systemd", "strace", "ssh", "udev", "iptables", "jq",
+		).
+			WithExec([]string{"systemctl", "enable", "ssh"}).
+			WithExec([]string{"update-alternatives", "--set", "iptables", "/usr/sbin/iptables-legacy"}).
+			WithMountedFile("/tmp/packages-microsoft-prod.deb", deb).
+			WithExec([]string{"/usr/bin/dpkg", "-i", "/tmp/packages-microsoft-prod.deb"}),
+		client.Container().Rootfs().WithNewFile("install.sh", debInstall, dagger.DirectoryWithNewFileOpts{Permissions: 0744}).File("install.sh")
 }
 
-func Buster(ctx context.Context, t *testing.T, client *dagger.Client) *dagger.Container {
+func Buster(ctx context.Context, t *testing.T, client *dagger.Client) (*dagger.Container, *dagger.File) {
 	deb := client.HTTP("https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb")
 
 	c := client.Container().From(targets.BusterRef)
 	return apt.Install(c, client.CacheVolume(targets.BusterAptCacheKey), client.CacheVolume(targets.BusterAptLibCacheKey),
-		"systemd", "strace", "ssh", "udev", "iptables", "jq",
-	).
-		WithExec([]string{"systemctl", "enable", "ssh"}).
-		WithExec([]string{"update-alternatives", "--set", "iptables", "/usr/sbin/iptables-legacy"}).
-		WithMountedFile("/tmp/packages-microsoft-prod.deb", deb).
-		WithExec([]string{"/usr/bin/dpkg", "-i", "/tmp/packages-microsoft-prod.deb"}).
-		WithNewFile("/opt/moby/install.sh", dagger.ContainerWithNewFileOpts{Contents: debInstall, Permissions: 0744})
+			"systemd", "strace", "ssh", "udev", "iptables", "jq",
+		).
+			WithExec([]string{"systemctl", "enable", "ssh"}).
+			WithExec([]string{"update-alternatives", "--set", "iptables", "/usr/sbin/iptables-legacy"}).
+			WithMountedFile("/tmp/packages-microsoft-prod.deb", deb).
+			WithExec([]string{"/usr/bin/dpkg", "-i", "/tmp/packages-microsoft-prod.deb"}),
+		client.Container().Rootfs().WithNewFile("install.sh", debInstall, dagger.DirectoryWithNewFileOpts{Permissions: 0744}).File("install.sh")
 }
 
-func Rhel9(ctx context.Context, t *testing.T, client *dagger.Client) *dagger.Container {
+func Rhel9(ctx context.Context, t *testing.T, client *dagger.Client) (*dagger.Container, *dagger.File) {
 	return client.Container().From(targets.Rhel9Ref).
-		WithExec([]string{
-			"dnf", "install", "-y",
-			"createrepo_c", "systemd", "strace", "openssh-server", "openssh-clients", "udev", "iptables", "dnf-command(config-manager)", "jq",
-		}).
-		WithExec([]string{"systemctl", "enable", "sshd"}).
-		WithExec([]string{"bash", "-c", `
+			WithExec([]string{
+				"dnf", "install", "-y",
+				"createrepo_c", "systemd", "strace", "openssh-server", "openssh-clients", "udev", "iptables", "dnf-command(config-manager)", "jq",
+			}).
+			WithExec([]string{"systemctl", "enable", "sshd"}).
+			WithExec([]string{"bash", "-c", `
 			dnf install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
-		`}).
-		WithNewFile("/opt/moby/install.sh", dagger.ContainerWithNewFileOpts{Contents: rhel8Install, Permissions: 0744})
+		`}),
+		client.Container().Rootfs().WithNewFile("install.sh", rhel8Install, dagger.DirectoryWithNewFileOpts{Permissions: 0744}).File("install.sh")
 }
 
-func Rhel8(ctx context.Context, t *testing.T, client *dagger.Client) *dagger.Container {
+func Rhel8(ctx context.Context, t *testing.T, client *dagger.Client) (*dagger.Container, *dagger.File) {
 	return client.Container().From(targets.Rhel8Ref).
-		WithExec([]string{
-			"dnf", "install", "-y",
-			"createrepo_c", "systemd", "strace", "openssh-server", "openssh-clients", "udev", "iptables", "dnf-command(config-manager)", "dnf-utils", "util-linux", "jq",
-		}).
-		WithExec([]string{"systemctl", "enable", "sshd"}).
-		WithExec([]string{"bash", "-c", `
+			WithExec([]string{
+				"dnf", "install", "-y",
+				"createrepo_c", "systemd", "strace", "openssh-server", "openssh-clients", "udev", "iptables", "dnf-command(config-manager)", "dnf-utils", "util-linux", "jq",
+			}).
+			WithExec([]string{"systemctl", "enable", "sshd"}).
+			WithExec([]string{"bash", "-c", `
 			dnf install -y https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm
-		`}).
-		WithNewFile("/opt/moby/install.sh", dagger.ContainerWithNewFileOpts{Contents: rhel8Install, Permissions: 0744})
+		`}),
+		client.Container().Rootfs().WithNewFile("install.sh", rhel8Install, dagger.DirectoryWithNewFileOpts{Permissions: 0744}).File("install.sh")
 }
 
-func Mariner2(ctx context.Context, t *testing.T, client *dagger.Client) *dagger.Container {
+func Mariner2(ctx context.Context, t *testing.T, client *dagger.Client) (*dagger.Container, *dagger.File) {
 	c := client.Container().From(targets.Mariner2Ref).
 		WithExec([]string{
 			"tdnf", "install", "-y",
 			"createrepo_c", "systemd", "strace", "openssh-server", "openssh-clients", "udev", "iptables", "dnf-command(config-manager)", "dnf-utils", "util-linux", "jq",
 		}).
 		WithExec([]string{"systemctl", "enable", "sshd"}).
-		WithExec([]string{"sed", "-i", "s/PermitRootLogin no/PermitRootLogin yes/", "/etc/ssh/sshd_config"}).
-		WithNewFile("/opt/moby/install.sh", dagger.ContainerWithNewFileOpts{Contents: mariner2Install, Permissions: 0744})
+		WithExec([]string{"sed", "-i", "s/PermitRootLogin no/PermitRootLogin yes/", "/etc/ssh/sshd_config"})
 
 	clientPkg := client.Pipeline("Fetch extra mariner packages")
 	p, err := clientPkg.DefaultPlatform(ctx)
@@ -186,5 +186,5 @@ func Mariner2(ctx context.Context, t *testing.T, client *dagger.Client) *dagger.
 		}
 	}
 
-	return c
+	return c, client.Container().Rootfs().WithNewFile("install.sh", mariner2Install, dagger.DirectoryWithNewFileOpts{Permissions: 0744}).File("install.sh")
 }

--- a/package_test.go
+++ b/package_test.go
@@ -54,7 +54,7 @@ func testPackage(ctx context.Context, t *testing.T, client *dagger.Client, spec 
 
 	qemu := testutil.NewQemuImg(ctx, client.Pipeline("Qemu"))
 
-	c := getContainer(ctx, t, client.Pipeline("Setup "+spec.Distro+"/"+spec.Arch))
+	c, installer := getContainer(ctx, t, client.Pipeline("Setup "+spec.Distro+"/"+spec.Arch))
 
 	vmImage := c.Pipeline("Build VM rootfs").
 		WithDirectory("/opt/bats", batsCore).
@@ -128,6 +128,7 @@ func testPackage(ctx context.Context, t *testing.T, client *dagger.Client, spec 
 		WithMountedDirectory("/tmp/pkg", buildOutput).
 		WithNewFile("/usr/local/bin/test_runner.sh", dagger.ContainerWithNewFileOpts{Contents: testRunnerCmd, Permissions: 0774}).
 		WithServiceBinding(svc, runner).
+		WithMountedFile("/opt/moby/install.sh", installer).
 		// TODO: It would be really nice if we could move these tests out of bats and into go tests.
 		//    Gist of it would be to create a go subtest for each test case and use ssh to run the test.
 		//    This would just allow us to more easily integrate with the test framework and get better reporting.

--- a/package_test.go
+++ b/package_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"crypto/rand"
 	_ "embed"
@@ -40,7 +39,7 @@ var (
 
 func testPackage(ctx context.Context, t *testing.T, client *dagger.Client, spec *archive.Spec) {
 	// set up the daemon container
-	getContainer, ok := distros[spec.Distro]
+	helper, ok := distros[spec.Distro]
 	if !ok {
 		t.Fatalf("unknown distro: %s", spec.Distro)
 	}
@@ -54,7 +53,7 @@ func testPackage(ctx context.Context, t *testing.T, client *dagger.Client, spec 
 
 	qemu := testutil.NewQemuImg(ctx, client.Pipeline("Qemu"))
 
-	c, installer := getContainer(ctx, t, client.Pipeline("Setup "+spec.Distro+"/"+spec.Arch))
+	c := helper.Image(ctx, t, client.Pipeline("Setup "+spec.Distro+"/"+spec.Arch))
 
 	vmImage := c.Pipeline("Build VM rootfs").
 		WithDirectory("/opt/bats", batsCore).
@@ -124,11 +123,11 @@ func testPackage(ctx context.Context, t *testing.T, client *dagger.Client, spec 
 		WithMountedCache("/tmp/sockets", sockets).
 		WithEnvVariable("SSH_AUTH_SOCK", "/tmp/sockets/agent.sock").
 		// Set the test package version in the environment so the test runner can use it to install and test by package version
-		WithEnvVariable("TEST_EVAL_VARS", pkgTestEnvEval(ctx, t, spec, c)).
+		WithEnvVariable("TEST_EVAL_VARS", pkgTestEnvEval(ctx, t, spec, helper)).
 		WithMountedDirectory("/tmp/pkg", buildOutput).
 		WithNewFile("/usr/local/bin/test_runner.sh", dagger.ContainerWithNewFileOpts{Contents: testRunnerCmd, Permissions: 0774}).
 		WithServiceBinding(svc, runner).
-		WithMountedFile("/opt/moby/install.sh", installer).
+		WithMountedFile("/opt/moby/install.sh", helper.Installer(ctx, client)).
 		// TODO: It would be really nice if we could move these tests out of bats and into go tests.
 		//    Gist of it would be to create a go subtest for each test case and use ssh to run the test.
 		//    This would just allow us to more easily integrate with the test framework and get better reporting.
@@ -240,7 +239,7 @@ func TestPackages(t *testing.T) {
 				// Set the tag to a very large number so that we can ensure this
 				// is the one that the package manager will install instead of
 				// the one from the distro repos.
-				pkg.Tag = "99.99.99"
+				pkg.Tag = "99.99.99+azure"
 
 				t.Run(pkg.Pkg, func(t *testing.T) {
 					t.Parallel()
@@ -269,57 +268,9 @@ func makeBats(client *dagger.Client) (core *dagger.Directory, helpers *dagger.Di
 	return core, helpers
 }
 
-// getPkgTargetID gets the version ID of the distro that the package has set on it
-// This is taken from /etc/os-release, specifically the concatenated ID and the VERSION_ID fields.
-func getPkgTargetID(ctx context.Context, t *testing.T, c *dagger.Container) string {
-	dt, err := c.File("/etc/os-release").Contents(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	scanner := bufio.NewScanner(strings.NewReader(dt))
-	var (
-		id      string
-		version string
-	)
-	for scanner.Scan() {
-		line := scanner.Text()
-		key, val, ok := strings.Cut(line, "=")
-		if !ok {
-			t.Fatalf("unexpected line in /etc/os-release: %s", line)
-		}
-
-		switch key {
-		case "ID":
-			id, err = strconv.Unquote(val)
-			if err != nil {
-				if err != strconv.ErrSyntax {
-					t.Fatal(err)
-				}
-				id = val
-			}
-		case "VERSION_ID":
-			version, err = strconv.Unquote(val)
-			if err != nil {
-				if err != nil {
-					if err != strconv.ErrSyntax {
-						t.Fatal(err)
-					}
-					version = val
-				}
-			}
-		}
-	}
-
-	if id == "" || version == "" {
-		t.Fatalf("missing ID or VERSION_ID in /etc/os-release: %s", dt)
-	}
-	return id + version
-}
-
 // pkgTestEnvEval generates environment variables (or rather a shell script that can be sourced/eval'd to set them) used by the bats package tests
 // as the expected package version/commit hash/etc to be installed.
-func pkgTestEnvEval(ctx context.Context, t *testing.T, spec *archive.Spec, c *dagger.Container) string {
+func pkgTestEnvEval(ctx context.Context, t *testing.T, spec *archive.Spec, helper DistroTestHelper) string {
 	// package name should be moby-<pkg>
 	_, pkg, ok := strings.Cut(spec.Pkg, "-")
 	if !ok {
@@ -327,8 +278,6 @@ func pkgTestEnvEval(ctx context.Context, t *testing.T, spec *archive.Spec, c *da
 	}
 
 	pkg = strings.ToUpper(pkg)
-
-	versionID := getPkgTargetID(ctx, t, c)
 
 	b := &strings.Builder{}
 
@@ -342,7 +291,7 @@ func pkgTestEnvEval(ctx context.Context, t *testing.T, spec *archive.Spec, c *da
 	}
 
 	// This is used to both install the specific package version as well as check the package version in the tests
-	v := fmt.Sprintf(`TEST_%s_PACKAGE_VERSION="%s+azure-%su%s"`, pkg, spec.Tag, versionID, spec.Revision)
+	v := fmt.Sprintf(`TEST_%s_PACKAGE_VERSION="%s"`, pkg, helper.FormatVersion(spec.Tag, spec.Revision))
 	writeVar(v)
 
 	// This makes it to the tests can check the git commit set on the binary itself
@@ -350,7 +299,7 @@ func pkgTestEnvEval(ctx context.Context, t *testing.T, spec *archive.Spec, c *da
 	writeVar(v)
 
 	// This is used to check the version reported by the binary
-	v = fmt.Sprintf(`TEST_%s_VERSION="%s+azure-%s"`, pkg, spec.Tag, spec.Revision)
+	v = fmt.Sprintf(`TEST_%s_VERSION="%s-%s"`, pkg, spec.Tag, spec.Revision)
 	writeVar(v)
 
 	return b.String()

--- a/pkg/archive/deb.go
+++ b/pkg/archive/deb.go
@@ -82,7 +82,7 @@ func (d *DebPackager) Package(client *dagger.Client, c *dagger.Container, projec
 	dir := client.Directory()
 	rootDir := "/package"
 
-	version := fmt.Sprintf("%s+azure-%su%s", project.Tag, debDistroMap[project.Distro], project.Revision)
+	version := fmt.Sprintf("%s-%su%s", project.Tag, debDistroMap[project.Distro], project.Revision)
 	c = c.WithDirectory(rootDir, dir)
 	c = d.moveStaticFiles(c, rootDir)
 	c = d.withControlFile(c, version, project)

--- a/pkg/archive/rpm.go
+++ b/pkg/archive/rpm.go
@@ -72,13 +72,13 @@ func (r *RpmPackager) Package(client *dagger.Client, c *dagger.Container, projec
 	pkgDir := c.Directory(rootDir)
 	fpm := fpmContainer(client, r.mirrorPrefix)
 
-	filename := fmt.Sprintf("%s-%s+azure-%s.%s.%s.rpm", project.Pkg, project.Tag, project.Revision, rpmDistroMap[project.Distro], rpmArchMap[project.Arch])
+	filename := fmt.Sprintf("%s-%s-%s.%s.%s.rpm", project.Pkg, project.Tag, project.Revision, rpmDistroMap[project.Distro], rpmArchMap[project.Arch])
 
 	fpmArgs := []string{"fpm",
 		"-s", "dir",
 		"-t", "rpm",
 		"-n", project.Pkg,
-		"--version", project.Tag + "+azure",
+		"--version", project.Tag,
 		"--iteration", project.Revision,
 		"--rpm-dist", rpmDistroMap[project.Distro],
 		"--architecture", strings.Replace(project.Arch, "/", "", -1),

--- a/tests/mariner2/install.sh
+++ b/tests/mariner2/install.sh
@@ -21,7 +21,7 @@ prepare_local_yum() {
 }
 
 install() {
-    tdnf install -y --nogpgcheck \
+    dnf install -y --nogpgcheck \
         moby-engine-"${TEST_ENGINE_PACKAGE_VERSION}*" \
         moby-cli-"${TEST_CLI_PACKAGE_VERSION}*" \
         moby-containerd-"${TEST_CONTAINERD_PACKAGE_VERSION}*" \

--- a/tests/test_runner.sh
+++ b/tests/test_runner.sh
@@ -32,6 +32,8 @@ for f in $(
     echo "... Ok" >&2
 done
 
+scpCmd /opt/moby/install.sh ${SSH_HOST}:/opt/moby/install.sh || exit
+
 echo "Installing Moby packages..." >&2
 sshCmd "env -S \"${TEST_EVAL_VARS}\" /opt/moby/install.sh" || exit
 echo "Running tests" >&2


### PR DESCRIPTION
- do not copy installer scripts to test vm rootfs (scp at runtime instead)
- use dnf in mariner installer script
- Do not automatically apply +azure to package names
- Move test img setup behind interfaces and fix version formatting issues for the test's expected version

I recommend going through this commit by commit