### PR TITLE
Split package definitions by distro

### DIFF
--- a/moby-buildx/mapping.go
+++ b/moby-buildx/mapping.go
@@ -10,6 +10,7 @@ var (
 		"focal":    DebArchive,
 		"centos7":  RPMArchive,
 		"rhel8":    RPMArchive,
+		"rhel9":    RPMArchive,
 		"windows":  BaseArchive,
 		"jammy":    DebArchive,
 		"mariner2": MarinerArchive,

--- a/moby-buildx/mapping.go
+++ b/moby-buildx/mapping.go
@@ -3,26 +3,22 @@ package buildx
 import "github.com/Azure/moby-packaging/pkg/archive"
 
 var (
-	Mapping = map[string]string{
-		"src/docker-buildx": "/usr/libexec/docker/cli-plugins/docker-buildx",
-	}
-	Mapping2 = []archive.File{
-		{
-			Source: "/build/src/docker-buildx",
-			Dest:   "/usr/libexec/docker/cli-plugins/docker-buildx",
-		},
-		{
-			Source: "/build/legal/LICENSE",
-			Dest:   "/usr/share/doc/moby-buildx/LICENSE",
-		},
-		{
-			Source:   "/build/legal/NOTICE",
-			Dest:     "/usr/share/doc/moby-buildx/NOTICE.gz",
-			Compress: true,
-		},
+	Archives = map[string]archive.Archive{
+		"buster":   DebArchive,
+		"bullseye": DebArchive,
+		"bionic":   DebArchive,
+		"focal":    DebArchive,
+		"centos7":  RPMArchive,
+		"rhel8":    RPMArchive,
+		"windows":  BaseArchive,
+		"jammy":    DebArchive,
+		"mariner2": MarinerArchive,
 	}
 
-	Archive = archive.Archive{
+	BaseArchive = archive.Archive{
+		Name:        "moby-buildx",
+		Webpage:     "https://github.com/docker/buildx",
+		Description: `A Docker CLI plugin for extended build capabilities with BuildKit`,
 		Files: []archive.File{
 			{
 				Source: "/build/src/docker-buildx",
@@ -41,37 +37,64 @@ var (
 		Binaries: []string{
 			"/build/src/docker-buildx",
 		},
-		RuntimeDeps: archive.PkgKindMap{
-			archive.PkgKindRPM: {
-				"/bin/sh",
-				"container-selinux >= 2:2.95",
-				"device-mapper-libs >= 1.02.90-1",
-				"iptables",
-				"libcgroup",
-				"moby-containerd >= 1.3.9",
-				"moby-runc >= 1.0.2",
-				"systemd-units",
-				"tar",
-				"xz",
-			},
-		},
-		Name:    "moby-buildx",
-		Webpage: "https://github.com/docker/buildx",
-		Recommends: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"moby-cli",
-			},
-		},
-		Conflicts: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"docker-ce",
-				"docker-ee",
-			},
-			archive.PkgKindRPM: {
-				"docker-ce",
-				"docker-ee",
-			},
-		},
-		Description: `A Docker CLI plugin for extended build capabilities with BuildKit`,
 	}
+
+	DebArchive = archive.Archive{
+		Name:        BaseArchive.Name,
+		Webpage:     BaseArchive.Webpage,
+		Description: BaseArchive.Description,
+		Files:       BaseArchive.Files,
+		Binaries: []string{
+			"/build/src/docker-buildx",
+		},
+		Recommends: []string{
+			"moby-cli",
+		},
+		Conflicts: []string{
+			"docker-ce",
+			"docker-ee",
+		},
+	}
+
+	RPMArchive = archive.Archive{
+		Name:        BaseArchive.Name,
+		Webpage:     BaseArchive.Webpage,
+		Description: BaseArchive.Description,
+		Files:       BaseArchive.Files,
+		Binaries: []string{
+			"/build/src/docker-buildx",
+		},
+		RuntimeDeps: []string{
+			"/bin/sh",
+			"container-selinux >= 2:2.95",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		},
+		Conflicts: []string{
+			"docker-ce",
+			"docker-ee",
+		},
+	}
+
+	MarinerArchive = func() archive.Archive {
+		m := RPMArchive
+		m.RuntimeDeps = []string{
+			"/bin/sh",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		}
+		return m
+	}()
 )

--- a/moby-cli/mapping.go
+++ b/moby-cli/mapping.go
@@ -22,6 +22,7 @@ var (
 		"focal":    DebArchive,
 		"centos7":  RPMArchive,
 		"rhel8":    RPMArchive,
+		"rhel9":    RPMArchive,
 		"windows":  BaseArchive,
 		"jammy":    DebArchive,
 		"mariner2": MarinerArchive,

--- a/moby-cli/mapping.go
+++ b/moby-cli/mapping.go
@@ -15,14 +15,19 @@ var (
 	//go:embed postinstall/rpm/postinstall
 	rpmPostInst string
 
-	Mapping = map[string]string{
-		"src/build":                          "/usr/bin",
-		"src/contrib/completion/zsh/_docker": "/usr/share/zsh/vendor-completions/_docker",
-		"src/man/man1":                       "/usr/share/man/man1",
-		"src/man/man8":                       "/usr/share/man/man8",
+	Archives = map[string]archive.Archive{
+		"buster":   DebArchive,
+		"bullseye": DebArchive,
+		"bionic":   DebArchive,
+		"focal":    DebArchive,
+		"centos7":  RPMArchive,
+		"rhel8":    RPMArchive,
+		"windows":  BaseArchive,
+		"jammy":    DebArchive,
+		"mariner2": MarinerArchive,
 	}
-	Mapping2 = []archive.File{}
-	Archive  = archive.Archive{
+
+	BaseArchive = archive.Archive{
 		Name:    "moby-cli",
 		Webpage: "https://github.com/docker/cli",
 		Files: []archive.File{
@@ -55,76 +60,6 @@ var (
 		},
 		Binaries:    []string{"/build/src/build/docker"},
 		WinBinaries: []string{"/build/src/build/docker.exe"},
-		RuntimeDeps: map[archive.PkgKind][]string{
-			archive.PkgKindRPM: {
-				"/bin/sh",
-				"container-selinux >= 2:2.95",
-				"device-mapper-libs >= 1.02.90-1",
-				"iptables",
-				"libcgroup",
-				"moby-containerd >= 1.3.9",
-				"moby-runc >= 1.0.2",
-				"systemd-units",
-				"tar",
-				"xz",
-			},
-		},
-		Recommends: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"ca-certificates",
-				"git",
-				"moby-buildx",
-				"pigz",
-				"xz-utils",
-			},
-		},
-		Suggests: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"moby-engine",
-			},
-		},
-		Conflicts: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"docker",
-				"docker-ce",
-				"docker-ce-cli",
-				"docker-ee",
-				"docker-ee-cli",
-				"docker-engine",
-				"docker-engine-cs",
-				"docker.io",
-				"lxc-docker",
-				"lxc-docker-virtual-package",
-			},
-		},
-		Replaces: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"docker",
-				"docker-ce",
-				"docker-ce-cli",
-				"docker-ee",
-				"docker-ee-cli",
-				"docker-engine",
-				"docker-engine-cs",
-				"docker.io",
-				"lxc-docker",
-				"lxc-docker-virtual-package",
-			},
-		},
-		InstallScripts: archive.PkgInstallMap{
-			archive.PkgKindDeb: {
-				{
-					When:   archive.PkgActionPostInstall,
-					Script: debPostInst,
-				},
-			},
-			archive.PkgKindRPM: {
-				{
-					When:   archive.PkgActionPostInstall,
-					Script: rpmPostInst,
-				},
-			},
-		},
 		Description: `Docker container platform (client package)
  Docker is a platform for developers and sysadmins to develop, ship, and run
  applications. Docker lets you quickly assemble applications from components and
@@ -133,4 +68,95 @@ var (
  .
  This package provides the "docker" client binary (and supporting files).`,
 	}
+
+	DebArchive = archive.Archive{
+		Name:        BaseArchive.Name,
+		Webpage:     BaseArchive.Webpage,
+		Files:       BaseArchive.Files,
+		Binaries:    []string{"/build/src/build/docker"},
+		RuntimeDeps: []string{},
+		Recommends: []string{
+			"ca-certificates",
+			"git",
+			"moby-buildx",
+			"pigz",
+			"xz-utils",
+		},
+		Suggests: []string{
+			"moby-engine",
+		},
+		Conflicts: []string{
+			"docker",
+			"docker-ce",
+			"docker-ce-cli",
+			"docker-ee",
+			"docker-ee-cli",
+			"docker-engine",
+			"docker-engine-cs",
+			"docker.io",
+			"lxc-docker",
+			"lxc-docker-virtual-package",
+		},
+		Replaces: []string{
+			"docker",
+			"docker-ce",
+			"docker-ce-cli",
+			"docker-ee",
+			"docker-ee-cli",
+			"docker-engine",
+			"docker-engine-cs",
+			"docker.io",
+			"lxc-docker",
+			"lxc-docker-virtual-package",
+		},
+		InstallScripts: []archive.InstallScript{
+			{
+				When:   archive.PkgActionPostInstall,
+				Script: debPostInst,
+			},
+		},
+		Description: BaseArchive.Description,
+	}
+
+	RPMArchive = archive.Archive{
+		Name:     BaseArchive.Name,
+		Webpage:  BaseArchive.Webpage,
+		Files:    BaseArchive.Files,
+		Binaries: []string{"/build/src/build/docker"},
+		RuntimeDeps: []string{
+			"/bin/sh",
+			"container-selinux >= 2:2.95",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		},
+		InstallScripts: []archive.InstallScript{
+			{
+				When:   archive.PkgActionPostInstall,
+				Script: rpmPostInst,
+			},
+		},
+		Description: BaseArchive.Description,
+	}
+
+	MarinerArchive = func() archive.Archive {
+		m := RPMArchive
+		m.RuntimeDeps = []string{
+			"/bin/sh",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		}
+		return m
+	}()
 )

--- a/moby-compose/mapping.go
+++ b/moby-compose/mapping.go
@@ -10,6 +10,7 @@ var (
 		"focal":    DebArchive,
 		"centos7":  RPMArchive,
 		"rhel8":    RPMArchive,
+		"rhel9":    RPMArchive,
 		"windows":  BaseArchive,
 		"jammy":    DebArchive,
 		"mariner2": MarinerArchive,

--- a/moby-compose/mapping.go
+++ b/moby-compose/mapping.go
@@ -3,26 +3,19 @@ package compose
 import "github.com/Azure/moby-packaging/pkg/archive"
 
 var (
-	Mapping = map[string]string{
-		"src/bin/docker-compose": "/usr/libexec/docker/cli-plugins/docker-compose",
-	}
-	Mapping2 = []archive.File{
-		{
-			Source: "/build/src/bin/docker-compose",
-			Dest:   "/usr/libexec/docker/cli-plugins/docker-compose",
-		},
-		{
-			Source: "/build/legal/LICENSE",
-			Dest:   "/usr/share/doc/moby-compose/LICENSE",
-		},
-		{
-			Source:   "/build/legal/NOTICE",
-			Dest:     "/usr/share/doc/moby-compose/NOTICE.gz",
-			Compress: true,
-		},
+	Archives = map[string]archive.Archive{
+		"buster":   DebArchive,
+		"bullseye": DebArchive,
+		"bionic":   DebArchive,
+		"focal":    DebArchive,
+		"centos7":  RPMArchive,
+		"rhel8":    RPMArchive,
+		"windows":  BaseArchive,
+		"jammy":    DebArchive,
+		"mariner2": MarinerArchive,
 	}
 
-	Archive = archive.Archive{
+	BaseArchive = archive.Archive{
 		Name:    "moby-compose",
 		Webpage: "https://github.com/docker/compose-cli",
 		Files: []archive.File{
@@ -40,41 +33,73 @@ var (
 				Compress: true,
 			},
 		},
-		Systemd:  []archive.Systemd{},
-		Postinst: []string{},
+		Description: `A Docker CLI plugin which allows you to run Docker Compose applications from the Docker CLI.`,
+	}
+
+	DebArchive = archive.Archive{
+		Name:        BaseArchive.Name,
+		Webpage:     BaseArchive.Webpage,
+		Files:       BaseArchive.Files,
+		Description: BaseArchive.Description,
 		Binaries: []string{
 			"/build/src/bin/docker-compose",
 		},
-		RuntimeDeps: map[archive.PkgKind][]string{
-			archive.PkgKindRPM: {
-				"/bin/sh",
-				"container-selinux >= 2:2.95",
-				"device-mapper-libs >= 1.02.90-1",
-				"iptables",
-				"libcgroup",
-				"moby-cli",
-				"moby-containerd >= 1.3.9",
-				"moby-runc >= 1.0.2",
-				"systemd-units",
-				"tar",
-				"xz",
-			},
-			archive.PkgKindDeb: {
-				"moby-cli",
-			},
+		RuntimeDeps: []string{
+			"moby-cli",
 		},
-		Conflicts: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"docker-ce",
-				"docker-ee",
-				"docker-ce-cli",
-				"docker-ee-cli",
-			},
-			archive.PkgKindRPM: {
-				"docker-ce",
-				"docker-ee",
-			},
+		Conflicts: []string{
+			"docker-ce",
+			"docker-ee",
+			"docker-ce-cli",
+			"docker-ee-cli",
 		},
-		Description: `A Docker CLI plugin which allows you to run Docker Compose applications from the Docker CLI.`,
+	}
+
+	RPMArchive = archive.Archive{
+		Name:    BaseArchive.Name,
+		Webpage: BaseArchive.Webpage,
+		Files:   BaseArchive.Files,
+		Binaries: []string{
+			"/build/src/bin/docker-compose",
+		},
+		RuntimeDeps: []string{
+			"/bin/sh",
+			"container-selinux >= 2:2.95",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"moby-cli",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		},
+		Conflicts: []string{
+			"docker-ce",
+			"docker-ee",
+		},
+		Description: BaseArchive.Description,
+	}
+
+	MarinerArchive = archive.Archive{
+		Name:     RPMArchive.Name,
+		Webpage:  RPMArchive.Webpage,
+		Files:    RPMArchive.Files,
+		Binaries: RPMArchive.Binaries,
+		RuntimeDeps: []string{
+			"/bin/sh",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"moby-cli",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		},
+		Conflicts:   RPMArchive.Conflicts,
+		Description: RPMArchive.Description,
 	}
 )

--- a/moby-containerd-shim-systemd/mapping.go
+++ b/moby-containerd-shim-systemd/mapping.go
@@ -14,13 +14,19 @@ var (
 	//go:embed postinstall/deb/postrm
 	debPostRm string
 
-	Mapping = map[string]string{
-		"src/bin/containerd-shim-systemd-v1":        "usr/bin/containerd-shim-systemd-v1",
-		"debian/containerd-shim-systemd-v1.service": "lib/systemd/system/containerd-shim-systemd-v1.service",
-		"debian/containerd-shim-systemd-v1.socket":  "lib/systemd/system/containerd-shim-systemd-v1.socket",
+	Archives = map[string]archive.Archive{
+		"buster":   DebArchive,
+		"bullseye": DebArchive,
+		"bionic":   DebArchive,
+		"focal":    DebArchive,
+		"centos7":  RPMArchive,
+		"rhel8":    RPMArchive,
+		"windows":  BaseArchive,
+		"jammy":    DebArchive,
+		"mariner2": MarinerArchive,
 	}
-	Mapping2 = []archive.File{}
-	Archive  = archive.Archive{
+
+	BaseArchive = archive.Archive{
 		Name:    "moby-containerd-shim-systemd",
 		Webpage: "https://github.com/cpuguy83/containerd-shim-systemd-v1",
 		Files: []archive.File{
@@ -48,50 +54,83 @@ var (
 				Dest:   "/lib/systemd/system/containerd-shim-systemd-v1.service",
 			},
 		},
-		Postinst: []string{},
 		Binaries: []string{
 			"/build/src/bin/containerd-shim-systemd-v1",
 		},
-		RuntimeDeps: map[archive.PkgKind][]string{
-			archive.PkgKindRPM: {
-				"/bin/sh",
-				"container-selinux >= 2:2.95",
-				"device-mapper-libs >= 1.02.90-1",
-				"iptables",
-				"libcgroup",
-				"moby-containerd >= 1.3.9",
-				"moby-containerd >= 1.6, systemd => 239",
-				"moby-runc >= 1.0.2",
-				"systemd-units",
-				"tar",
-				"xz",
-			},
-			archive.PkgKindDeb: {
-				"systemd (>= 239)",
-				"moby-containerd (>= 1.6)",
-			},
-		},
-		Recommends: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"moby-runc",
-			},
-		},
-		InstallScripts: archive.PkgInstallMap{
-			archive.PkgKindDeb: {
-				{
-					When:   archive.PkgActionPostInstall,
-					Script: debPostInstall,
-				},
-				{
-					When:   archive.PkgActionPreRemoval,
-					Script: debPreRm,
-				},
-				{
-					When:   archive.PkgActionPostRemoval,
-					Script: debPostRm,
-				},
-			},
-		},
 		Description: `A containerd shim runtime that uses systemd to monitor runc containers`,
 	}
+
+	DebArchive = archive.Archive{
+		Name:    BaseArchive.Name,
+		Webpage: BaseArchive.Webpage,
+		Files:   BaseArchive.Files,
+		Systemd: BaseArchive.Systemd,
+		Binaries: []string{
+			"/build/src/bin/containerd-shim-systemd-v1",
+		},
+		RuntimeDeps: []string{
+			"systemd (>= 239)",
+			"moby-containerd (>= 1.6)",
+		},
+		Recommends: []string{
+			"moby-runc",
+		},
+		InstallScripts: []archive.InstallScript{
+			{
+				When:   archive.PkgActionPostInstall,
+				Script: debPostInstall,
+			},
+			{
+				When:   archive.PkgActionPreRemoval,
+				Script: debPreRm,
+			},
+			{
+				When:   archive.PkgActionPostRemoval,
+				Script: debPostRm,
+			},
+		},
+		Description: BaseArchive.Description,
+	}
+
+	RPMArchive = archive.Archive{
+		Name:    BaseArchive.Name,
+		Webpage: BaseArchive.Webpage,
+		Files:   BaseArchive.Files,
+		Systemd: BaseArchive.Systemd,
+		Binaries: []string{
+			"/build/src/bin/containerd-shim-systemd-v1",
+		},
+		RuntimeDeps: []string{
+			"/bin/sh",
+			"container-selinux >= 2:2.95",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"moby-containerd >= 1.3.9",
+			"moby-containerd >= 1.6, systemd => 239",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		},
+		InstallScripts: []archive.InstallScript{},
+		Description:    BaseArchive.Description,
+	}
+
+	MarinerArchive = func() archive.Archive {
+		m := RPMArchive
+		m.RuntimeDeps = []string{
+			"/bin/sh",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"moby-containerd >= 1.3.9",
+			"moby-containerd >= 1.6, systemd => 239",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		}
+		return m
+	}()
 )

--- a/moby-containerd-shim-systemd/mapping.go
+++ b/moby-containerd-shim-systemd/mapping.go
@@ -21,6 +21,7 @@ var (
 		"focal":    DebArchive,
 		"centos7":  RPMArchive,
 		"rhel8":    RPMArchive,
+		"rhel9":    RPMArchive,
 		"windows":  BaseArchive,
 		"jammy":    DebArchive,
 		"mariner2": MarinerArchive,

--- a/moby-containerd/mapping.go
+++ b/moby-containerd/mapping.go
@@ -28,6 +28,7 @@ var (
 		"focal":    DebArchive,
 		"centos7":  RPMArchive,
 		"rhel8":    RPMArchive,
+		"rhel9":    RPMArchive,
 		"windows":  BaseArchive,
 		"jammy":    DebArchive,
 		"mariner2": MarinerArchive,

--- a/moby-engine/mapping.go
+++ b/moby-engine/mapping.go
@@ -25,8 +25,7 @@ var (
 	//go:embed postinstall/deb/postrm
 	debPostRm string
 
-	Mapping2 = []archive.File{}
-	Archive  = archive.Archive{
+	Archive = archive.Archive{
 		Name:    "moby-engine",
 		Webpage: "https://github.com/moby/moby",
 		Files: []archive.File{
@@ -43,103 +42,135 @@ var (
 		Systemd: []archive.Systemd{
 			{Source: "/build/systemd/docker.service", Dest: "/lib/systemd/system/docker.service"},
 		},
-		Postinst:    []string{"/build/debian/moby-engine.postinst"},
 		Binaries:    []string{"/build/bundles/dynbinary-daemon/dockerd", "/build/src/libnetwork/docker-proxy"},
 		WinBinaries: []string{"/build/src/bundles/binary-daemon/dockerd.exe"},
-		RuntimeDeps: map[archive.PkgKind][]string{
-			archive.PkgKindRPM: {
-				"/bin/sh",
-				"container-selinux >= 2:2.95",
-				"device-mapper-libs >= 1.02.90-1",
-				"iptables",
-				"libcgroup",
-				"moby-containerd >= 1.3.9",
-				"moby-runc >= 1.0.2",
-				"systemd-units",
-				"tar",
-				"xz",
-			},
-			archive.PkgKindDeb: {"moby-containerd (>= 1.4.3)", "moby-runc (>= 1.0.2)", "moby-init (>= 0.19.0)"},
+		Description: `Docker container platform (engine package)
+  Moby is an open-source project created by Docker to enable and accelerate software containerization.`,
+	}
+
+	DebArchive = archive.Archive{
+		Name:     Archive.Name,
+		Webpage:  Archive.Webpage,
+		Files:    Archive.Files,
+		Systemd:  Archive.Systemd,
+		Binaries: Archive.Binaries,
+		RuntimeDeps: []string{
+			"moby-containerd (>= 1.4.3)", "moby-runc (>= 1.0.2)", "moby-init (>= 0.19.0)",
 		},
-		Recommends: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"apparmor",
-				"ca-certificates",
-				"iptables",
-				"kmod",
-				"moby-cli",
-				"pigz",
-				"xz-utils",
-			},
+		Recommends: []string{
+			"apparmor",
+			"ca-certificates",
+			"iptables",
+			"kmod",
+			"moby-cli",
+			"pigz",
+			"xz-utils",
 		},
-		Suggests: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"aufs-tools",
-				"cgroupfs-mount | cgroup-lite",
-				"git",
-			},
+		Suggests: []string{
+			"aufs-tools",
+			"cgroupfs-mount | cgroup-lite",
+			"git",
 		},
-		Conflicts: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"docker",
-				"docker-ce",
-				"docker-ee",
-				"docker-engine",
-				"docker-engine-cs",
-				"docker.io",
-				"lxc-docker",
-				"lxc-docker-virtual-package",
-			},
-			archive.PkgKindRPM: {
-				"docker",
-				"docker-io",
-				"docker-engine-cs",
-				"docker-ee",
-			},
+		Conflicts: []string{
+			"docker",
+			"docker-ce",
+			"docker-ee",
+			"docker-engine",
+			"docker-engine-cs",
+			"docker.io",
+			"lxc-docker",
+			"lxc-docker-virtual-package",
 		},
-		Replaces: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"docker",
-				"docker-ce",
-				"docker-ee",
-				"docker-engine",
-				"docker-engine-cs",
-				"docker.io",
-				"lxc-docker",
-				"lxc-docker-virtual-package",
-			},
+		Replaces: []string{
+			"docker",
+			"docker-ce",
+			"docker-ee",
+			"docker-engine",
+			"docker-engine-cs",
+			"docker.io",
+			"lxc-docker",
+			"lxc-docker-virtual-package",
 		},
-		InstallScripts: archive.PkgInstallMap{
-			archive.PkgKindRPM: {
-				{
-					When:   archive.PkgActionPostInstall,
-					Script: rpmPostInstall,
-				},
-				{
-					When:   archive.PkgActionPreRemoval,
-					Script: rpmPreRm,
-				},
-				{
-					When:   archive.PkgActionUpgrade,
-					Script: rpmUpgrade,
-				},
+		InstallScripts: []archive.InstallScript{
+			{
+				When:   archive.PkgActionPostInstall,
+				Script: debPostInstall,
 			},
-			archive.PkgKindDeb: {
-				{
-					When:   archive.PkgActionPostInstall,
-					Script: debPostInstall,
-				},
-				{
-					When:   archive.PkgActionPreRemoval,
-					Script: debPreRm,
-				},
-				{
-					When:   archive.PkgActionPostRemoval,
-					Script: debPostRm,
-				},
+			{
+				When:   archive.PkgActionPreRemoval,
+				Script: debPreRm,
+			},
+			{
+				When:   archive.PkgActionPostRemoval,
+				Script: debPostRm,
 			},
 		},
 		Description: `Docker container platform (engine package)
   Moby is an open-source project created by Docker to enable and accelerate software containerization.`,
 	}
+
+	RPMArchive = archive.Archive{
+		Name:     Archive.Name,
+		Webpage:  Archive.Webpage,
+		Files:    Archive.Files,
+		Systemd:  Archive.Systemd,
+		Binaries: Archive.Binaries,
+		RuntimeDeps: []string{
+			"/bin/sh",
+			"container-selinux >= 2:2.95",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		},
+		Recommends: []string{},
+		Suggests:   []string{},
+		Conflicts: []string{
+			"docker",
+			"docker-io",
+			"docker-engine-cs",
+			"docker-ee",
+		},
+		Replaces: []string{},
+		InstallScripts: []archive.InstallScript{
+			{
+				When:   archive.PkgActionPostInstall,
+				Script: rpmPostInstall,
+			},
+			{
+				When:   archive.PkgActionPreRemoval,
+				Script: rpmPreRm,
+			},
+			{
+				When:   archive.PkgActionUpgrade,
+				Script: rpmUpgrade,
+			},
+		},
+		Description: `Docker container platform (engine package)
+  Moby is an open-source project created by Docker to enable and accelerate software containerization.`,
+	}
+
+	MarinerArchive = NewMarinerArchive()
 )
+
+func NewMarinerArchive() archive.Archive {
+	ret := RPMArchive
+
+	ret.RuntimeDeps = []string{
+		"/bin/sh",
+		"device-mapper-libs >= 1.02.90-1",
+		"iptables",
+		"libcgroup",
+		"moby-containerd >= 1.3.9",
+		"moby-runc >= 1.0.2",
+		"systemd-units",
+		"tar",
+		"xz",
+	}
+
+	return ret
+}

--- a/moby-engine/mapping.go
+++ b/moby-engine/mapping.go
@@ -25,7 +25,19 @@ var (
 	//go:embed postinstall/deb/postrm
 	debPostRm string
 
-	Archive = archive.Archive{
+	Archives = map[string]archive.Archive{
+		"buster":   DebArchive,
+		"bullseye": DebArchive,
+		"bionic":   DebArchive,
+		"focal":    DebArchive,
+		"centos7":  RPMArchive,
+		"rhel8":    RPMArchive,
+		"windows":  BaseArchive,
+		"jammy":    DebArchive,
+		"mariner2": MarinerArchive,
+	}
+
+	BaseArchive = archive.Archive{
 		Name:    "moby-engine",
 		Webpage: "https://github.com/moby/moby",
 		Files: []archive.File{
@@ -49,11 +61,11 @@ var (
 	}
 
 	DebArchive = archive.Archive{
-		Name:     Archive.Name,
-		Webpage:  Archive.Webpage,
-		Files:    Archive.Files,
-		Systemd:  Archive.Systemd,
-		Binaries: Archive.Binaries,
+		Name:     BaseArchive.Name,
+		Webpage:  BaseArchive.Webpage,
+		Files:    BaseArchive.Files,
+		Systemd:  BaseArchive.Systemd,
+		Binaries: BaseArchive.Binaries,
 		RuntimeDeps: []string{
 			"moby-containerd (>= 1.4.3)", "moby-runc (>= 1.0.2)", "moby-init (>= 0.19.0)",
 		},
@@ -110,11 +122,11 @@ var (
 	}
 
 	RPMArchive = archive.Archive{
-		Name:     Archive.Name,
-		Webpage:  Archive.Webpage,
-		Files:    Archive.Files,
-		Systemd:  Archive.Systemd,
-		Binaries: Archive.Binaries,
+		Name:     BaseArchive.Name,
+		Webpage:  BaseArchive.Webpage,
+		Files:    BaseArchive.Files,
+		Systemd:  BaseArchive.Systemd,
+		Binaries: BaseArchive.Binaries,
 		RuntimeDeps: []string{
 			"/bin/sh",
 			"container-selinux >= 2:2.95",
@@ -154,23 +166,21 @@ var (
   Moby is an open-source project created by Docker to enable and accelerate software containerization.`,
 	}
 
-	MarinerArchive = NewMarinerArchive()
+	MarinerArchive = func() archive.Archive {
+		m := RPMArchive
+
+		m.RuntimeDeps = []string{
+			"/bin/sh",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		}
+
+		return m
+	}()
 )
-
-func NewMarinerArchive() archive.Archive {
-	ret := RPMArchive
-
-	ret.RuntimeDeps = []string{
-		"/bin/sh",
-		"device-mapper-libs >= 1.02.90-1",
-		"iptables",
-		"libcgroup",
-		"moby-containerd >= 1.3.9",
-		"moby-runc >= 1.0.2",
-		"systemd-units",
-		"tar",
-		"xz",
-	}
-
-	return ret
-}

--- a/moby-engine/mapping.go
+++ b/moby-engine/mapping.go
@@ -32,6 +32,7 @@ var (
 		"focal":    DebArchive,
 		"centos7":  RPMArchive,
 		"rhel8":    RPMArchive,
+		"rhel9":    RPMArchive,
 		"windows":  BaseArchive,
 		"jammy":    DebArchive,
 		"mariner2": MarinerArchive,

--- a/moby-init/mapping.go
+++ b/moby-init/mapping.go
@@ -10,6 +10,7 @@ var (
 		"focal":    DebArchive,
 		"centos7":  RPMArchive,
 		"rhel8":    RPMArchive,
+		"rhel9":    RPMArchive,
 		"windows":  BaseArchive,
 		"jammy":    DebArchive,
 		"mariner2": MarinerArchive,

--- a/moby-init/mapping.go
+++ b/moby-init/mapping.go
@@ -3,23 +3,19 @@ package mobyinit
 import "github.com/Azure/moby-packaging/pkg/archive"
 
 var (
-	Mapping2 = []archive.File{
-		{
-			Source: "/build/src/build/tini-static",
-			Dest:   "usr/bin/docker-init",
-		},
-		{
-			Source: "/build/legal/LICENSE",
-			Dest:   "/usr/share/doc/moby-init/LICENSE",
-		},
-		{
-			Source:   "/build/legal/NOTICE",
-			Dest:     "/usr/share/doc/moby-init/NOTICE.gz",
-			Compress: true,
-		},
+	Archives = map[string]archive.Archive{
+		"buster":   DebArchive,
+		"bullseye": DebArchive,
+		"bionic":   DebArchive,
+		"focal":    DebArchive,
+		"centos7":  RPMArchive,
+		"rhel8":    RPMArchive,
+		"windows":  BaseArchive,
+		"jammy":    DebArchive,
+		"mariner2": MarinerArchive,
 	}
 
-	Archive = archive.Archive{
+	BaseArchive = archive.Archive{
 		Name:    "moby-init",
 		Webpage: "https://github.com/krallin/tini",
 		Files: []archive.File{
@@ -40,16 +36,6 @@ var (
 		Binaries: []string{
 			"/build/src/build/tini-static",
 		},
-		Conflicts: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"tini",
-			},
-		},
-		Replaces: archive.PkgKindMap{
-			archive.PkgKindDeb: {
-				"tini",
-			},
-		},
 		Description: `tiny but valid init for containers
  Tini is the simplest init you could think of.
  .
@@ -58,5 +44,31 @@ var (
  performing signal forwarding.`,
 	}
 
-	Dirs = []string{}
+	DebArchive = archive.Archive{
+		Name:    BaseArchive.Name,
+		Webpage: BaseArchive.Webpage,
+		Files:   BaseArchive.Files,
+		Binaries: []string{
+			"/build/src/build/tini-static",
+		},
+		Conflicts: []string{
+			"tini",
+		},
+		Replaces: []string{
+			"tini",
+		},
+		Description: BaseArchive.Description,
+	}
+
+	RPMArchive = archive.Archive{
+		Name:    BaseArchive.Name,
+		Webpage: BaseArchive.Webpage,
+		Files:   BaseArchive.Files,
+		Binaries: []string{
+			"/build/src/build/tini-static",
+		},
+		Description: BaseArchive.Description,
+	}
+
+	MarinerArchive = RPMArchive
 )

--- a/moby-runc/mapping.go
+++ b/moby-runc/mapping.go
@@ -10,6 +10,7 @@ var (
 		"focal":    DebArchive,
 		"centos7":  RPMArchive,
 		"rhel8":    RPMArchive,
+		"rhel9":    RPMArchive,
 		"windows":  BaseArchive,
 		"jammy":    DebArchive,
 		"mariner2": MarinerArchive,

--- a/moby-runc/mapping.go
+++ b/moby-runc/mapping.go
@@ -3,7 +3,19 @@ package runc
 import "github.com/Azure/moby-packaging/pkg/archive"
 
 var (
-	Archive = archive.Archive{
+	Archives = map[string]archive.Archive{
+		"buster":   DebArchive,
+		"bullseye": DebArchive,
+		"bionic":   DebArchive,
+		"focal":    DebArchive,
+		"centos7":  RPMArchive,
+		"rhel8":    RPMArchive,
+		"windows":  BaseArchive,
+		"jammy":    DebArchive,
+		"mariner2": MarinerArchive,
+	}
+
+	BaseArchive = archive.Archive{
 		Name:    "moby-runc",
 		Webpage: "https://github.com/opencontainers/runc",
 		Files: []archive.File{
@@ -16,39 +28,72 @@ var (
 		Systemd:  []archive.Systemd{},
 		Postinst: []string{},
 		Binaries: []string{"/build/src/runc"},
-		RuntimeDeps: map[archive.PkgKind][]string{
-			archive.PkgKindRPM: {
-				"/bin/sh",
-				"container-selinux >= 2:2.95",
-				"device-mapper-libs >= 1.02.90-1",
-				"iptables",
-				"libcgroup",
-				"libseccomp >= 2.3",
-				"moby-containerd >= 1.3.9",
-				"moby-runc >= 1.0.2",
-				"systemd-units",
-				"tar",
-				"xz",
-			},
-		},
-		Suggests: archive.PkgKindMap{
-			archive.PkgKindDeb: {"moby-containerd"},
-		},
-		Conflicts: archive.PkgKindMap{
-			archive.PkgKindDeb: {"runc", "moby-engine (<= 3.0.10)"},
-			archive.PkgKindRPM: {
-				"runc",
-				"runc-io",
-			},
-		},
-		Replaces: archive.PkgKindMap{
-			archive.PkgKindDeb: {"runc"},
-		},
-		Provides: archive.PkgKindMap{
-			archive.PkgKindDeb: {"runc"},
-		},
 		Description: `CLI tool for spawning and running containers according to the OCI specification
   runc is a CLI tool for spawning and running containers according to the OCI
   specification.`,
 	}
+
+	DebArchive = archive.Archive{
+		Name:        BaseArchive.Name,
+		Webpage:     BaseArchive.Webpage,
+		Files:       BaseArchive.Files,
+		Binaries:    []string{"/build/src/runc"},
+		RuntimeDeps: []string{},
+		Suggests: []string{
+			"moby-containerd",
+		},
+		Conflicts: []string{
+			"runc",
+			"moby-engine (<= 3.0.10)",
+		},
+		Replaces: []string{
+			"runc",
+		},
+		Provides: []string{
+			"runc",
+		},
+		Description: BaseArchive.Description,
+	}
+
+	RPMArchive = archive.Archive{
+		Name:     BaseArchive.Name,
+		Webpage:  BaseArchive.Webpage,
+		Files:    BaseArchive.Files,
+		Binaries: []string{"/build/src/runc"},
+		RuntimeDeps: []string{
+			"/bin/sh",
+			"container-selinux >= 2:2.95",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"libseccomp >= 2.3",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		},
+		Conflicts: []string{
+			"runc",
+			"runc-io",
+		},
+		Description: BaseArchive.Description,
+	}
+
+	MarinerArchive = func() archive.Archive {
+		m := RPMArchive
+		m.RuntimeDeps = []string{
+			"/bin/sh",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"libseccomp >= 2.3",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		}
+		return m
+	}()
 )

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -36,6 +36,7 @@ type InstallScript struct {
 
 type Archive struct {
 	Name    string
+	Distro  string
 	Webpage string
 	Files   []File
 	Systemd []Systemd

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -44,13 +44,13 @@ type Archive struct {
 	// required for debian dependency resolution
 	Binaries       []string
 	WinBinaries    []string
-	Recommends     PkgKindMap
-	Suggests       PkgKindMap
-	Conflicts      PkgKindMap
-	Replaces       PkgKindMap
-	Provides       PkgKindMap
-	BuildDeps      PkgKindMap
-	RuntimeDeps    PkgKindMap
-	InstallScripts PkgInstallMap
+	Recommends     []string
+	Suggests       []string
+	Conflicts      []string
+	Replaces       []string
+	Provides       []string
+	BuildDeps      []string
+	RuntimeDeps    []string
+	InstallScripts []InstallScript
 	Description    string
 }

--- a/pkg/archive/deb.go
+++ b/pkg/archive/deb.go
@@ -10,8 +10,8 @@ import (
 	"dagger.io/dagger"
 )
 
-func join(pkgKind PkgKind, m PkgKindMap) string {
-	return strings.Join(m[pkgKind], ", ")
+func join(a []string) string {
+	return strings.Join(a, ", ")
 }
 
 const ControlTemplate = `
@@ -126,8 +126,8 @@ func (d *DebPackager) moveStaticFiles(c *dagger.Container, rootdir string) *dagg
 func (d *DebPackager) withInstallScripts(c *dagger.Container) (*dagger.Container, []string) {
 	newArgs := []string{}
 
-	for i := range d.a.InstallScripts[PkgKindDeb] {
-		script := d.a.InstallScripts[PkgKindDeb][i]
+	for i := range d.a.InstallScripts {
+		script := d.a.InstallScripts[i]
 		var a []string
 		c, a = d.installScript(&script, c)
 		newArgs = append(newArgs, a...)

--- a/pkg/archive/rpm.go
+++ b/pkg/archive/rpm.go
@@ -86,8 +86,8 @@ func (r *RpmPackager) Package(client *dagger.Client, c *dagger.Container, projec
 		"--url", r.a.Webpage,
 	}
 
-	for i := range r.a.RuntimeDeps[PkgKindRPM] {
-		dep := r.a.RuntimeDeps[PkgKindRPM][i]
+	for i := range r.a.RuntimeDeps {
+		dep := r.a.RuntimeDeps[i]
 		if rpmPkgBlacklist.contains(project.Distro, dep) {
 			continue
 		}
@@ -95,8 +95,8 @@ func (r *RpmPackager) Package(client *dagger.Client, c *dagger.Container, projec
 		fpmArgs = append(fpmArgs, "-d", dep)
 	}
 
-	for i := range r.a.Conflicts[PkgKindRPM] {
-		conf := r.a.Conflicts[PkgKindRPM][i]
+	for i := range r.a.Conflicts {
+		conf := r.a.Conflicts[i]
 		fpmArgs = append(fpmArgs, "--conflicts", conf)
 	}
 
@@ -118,8 +118,8 @@ func (r *RpmPackager) Package(client *dagger.Client, c *dagger.Container, projec
 func (r *RpmPackager) withInstallScripts(c *dagger.Container) (*dagger.Container, []string) {
 	newArgs := []string{}
 
-	for i := range r.a.InstallScripts[PkgKindRPM] {
-		script := r.a.InstallScripts[PkgKindRPM][i]
+	for i := range r.a.InstallScripts {
+		script := r.a.InstallScripts[i]
 		var a []string
 		c, a = r.installScript(&script, c)
 		newArgs = append(newArgs, a...)


### PR DESCRIPTION
This enables future splitting by distro, which will be required going forward. For example, mariner is now separated since it doesn't use `container-selinux`.