### PR TITLE
packages: tini conflicts with moby-engine < 24

### DIFF
--- a/moby-tini/mapping.go
+++ b/moby-tini/mapping.go
@@ -54,6 +54,7 @@ var (
 		},
 		Conflicts: []string{
 			"tini",
+			"moby-engine (<< 24.0.0)",
 		},
 		Replaces: []string{
 			"tini",

--- a/moby-tini/mapping.go
+++ b/moby-tini/mapping.go
@@ -70,6 +70,9 @@ var (
 			"/build/src/build/tini-static",
 		},
 		Description: BaseArchive.Description,
+		Conflicts: []string{
+			"moby-engine < 24.0.0",
+		},
 	}
 
 	MarinerArchive = RPMArchive


### PR DESCRIPTION
This is required because versions of moby-engine prior to v24.0.0 will install `docker-init`, which will also be installed by moby-tini. Introducing this conflict prevents both from being installed.