### PR TITLE
Move docker-init to /usr/libexec/docker/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ $(COMPONENT_TARGETS):
 	$(DOCKER_BUILDX) bake $(PROGRESS) $@
 
 _LOCAL_PKG_DIR := $(OUTPUT)/$(DISTRO)
+ifneq ($(wildcard $(_LOCAL_PKG_DIR)/linux_*),)
+	_LOCAL_PKG_DIR := $(wildcard $(_LOCAL_PKG_DIR)/linux_*)
+endif
 ifneq ($(wildcard $(_LOCAL_PKG_DIR)/*),)
 export LOCAL_PKG_DIR ?= $(_LOCAL_PKG_DIR)
 endif

--- a/moby-tini/mapping.go
+++ b/moby-tini/mapping.go
@@ -22,7 +22,7 @@ var (
 		Files: []archive.File{
 			{
 				Source: "/build/src/build/tini-static",
-				Dest:   "usr/bin/docker-init",
+				Dest:   "usr/libexec/docker/docker-init",
 			},
 			{
 				Source: "/build/legal/LICENSE",
@@ -54,7 +54,6 @@ var (
 		},
 		Conflicts: []string{
 			"tini",
-			"moby-engine (<< 24.0.0)",
 		},
 		Replaces: []string{
 			"tini",
@@ -70,9 +69,7 @@ var (
 			"/build/src/build/tini-static",
 		},
 		Description: BaseArchive.Description,
-		Conflicts: []string{
-			"moby-engine < 24.0.0",
-		},
+		Conflicts:   []string{},
 	}
 
 	MarinerArchive = RPMArchive

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -11,12 +11,14 @@ fi
 @test "test docker run hello world" {
     run timeout --kill-after=60s 30s docker run ${TEST_PLATFORM} --rm hello-world
     assert_output --partial "This message shows that your installation appears to be working correctly"
+
+    # Make sure --init works which has an extra binary
+    run timeout --kill-after=60s 30s docker run --init --rm ${TEST_PLATFORM} docker.io/library/hello-world:latest
+    assert_output --partial "This message shows that your installation appears to be working correctly"
 }
 
 @test "extra docker binaries exists" {
     run command -v docker-proxy
-    assert_success
-    run command -v docker-init
     assert_success
 }
 


### PR DESCRIPTION
Starting with docker v24 dockerd will lookup docker-init in more than just $PATH, including /usr/libexec/docker/*.
Moving it here is both more "correct" in terms of linux userspace layout, but also gets us away from needing to mark moby-engine < 24 as conflicting.