### PR TITLE
pipeline: Enable queue consumer cron job

### DIFF
--- a/queue_consumer.yaml
+++ b/queue_consumer.yaml
@@ -8,15 +8,15 @@ parameters:
     type: string
     default: "__not_supplied"
 
-# trigger: none
+trigger: none
 
-# schedules:
-#  - cron: "0 2,10,18 * * *"
-#    displayName: "Process Queue"
-#    always: true
-#    branches:
-#      include:
-#        - main
+schedules:
+ - cron: "0 2,10,18 * * *"
+   displayName: "Process Queue"
+   always: true
+   branches:
+     include:
+       - main
 
 name: ${{ replace(parameters.build_id, '__not_supplied', '$(Date:yyyyMMdd)') }}.$(Rev:r)
 


### PR DESCRIPTION
Check the queue two hours after the build is triggered.