### PR TITLE
queue: fix error handling

### DIFF
--- a/cmd/pop/main.go
+++ b/cmd/pop/main.go
@@ -421,8 +421,8 @@ func resolveDuplicates(e []Envelope) (Envelope, error) {
 			if lastMsg.Artifact.Sha256Sum != thisMsg.Artifact.Sha256Sum {
 				return Envelope{}, fmt.Errorf(
 					"messages encountered with same filename and different sha256 digests; manual intervention will be required. "+
-						"digest[%d]: %s digest[%d]: %s",
-					i-1, lastMsg.Artifact.Sha256Sum, i, thisMsg.Artifact.Sha256Sum)
+						"filename: `%s`, digest[%d]: %s digest[%d]: %s",
+					lastMsg.Artifact.Name, i-1, lastMsg.Artifact.Sha256Sum, i, thisMsg.Artifact.Sha256Sum)
 			}
 
 			lastMsg = thisMsg

--- a/queue_consumer.yaml
+++ b/queue_consumer.yaml
@@ -64,7 +64,7 @@ stages:
               OUT_DIR: "$(Pipeline.Workspace)/downloaded"
             displayName: Pull Queued Packages
           - bash: |
-              readarray -t failed < <(jq -r '.[] | .content | fromjson.artifact.name' < "$MSG_DIR/failed_downloading")
+              readarray -t failed < <(jq '.[] | .content' < "$MSG_DIR/failed_downloading" | base64 -d | jq -r 'fromjson.artifact.name')
               for f in "${failed[@]}"; do
                 printf '##vso[task.logissue type=error;]failed downloading:  %s\n' "$f"
               done
@@ -93,7 +93,7 @@ stages:
               MSG_DIR: "$(Pipeline.Workspace)/messages"
             displayName: Upload Signed Packages to Prod Storage
           - bash: |
-              readarray -t failed < <(jq -r '.[] | .content | fromjson.artifact.name' < "$MSG_DIR/failed_singing_or_publishing")
+              readarray -t failed < <(jq '.[] | .content' < "$MSG_DIR/failed_singing_or_publishing" | base64 -d | jq -r 'fromjson.artifact.name')
               for f in "${failed[@]}"; do
                 printf '##vso[task.logissue type=error;]failed signing or uploading:  %s\n' "$f"
               done

--- a/queue_consumer.yaml
+++ b/queue_consumer.yaml
@@ -64,7 +64,7 @@ stages:
               OUT_DIR: "$(Pipeline.Workspace)/downloaded"
             displayName: Pull Queued Packages
           - bash: |
-              readarray -t failed < <(jq '.[] | .content' < "$MSG_DIR/failed_downloading" | base64 -d | jq -r 'fromjson.artifact.name')
+              readarray -t failed < <(jq -r '.[] | .content | @base64d | fromjson.artifact.name' < "$MSG_DIR/failed_downloading")
               for f in "${failed[@]}"; do
                 printf '##vso[task.logissue type=error;]failed downloading:  %s\n' "$f"
               done
@@ -93,7 +93,7 @@ stages:
               MSG_DIR: "$(Pipeline.Workspace)/messages"
             displayName: Upload Signed Packages to Prod Storage
           - bash: |
-              readarray -t failed < <(jq '.[] | .content' < "$MSG_DIR/failed_singing_or_publishing" | base64 -d | jq -r 'fromjson.artifact.name')
+              readarray -t failed < <(jq -r '.[] | .content | @base64d | fromjson.artifact.name' < "$MSG_DIR/failed_singing_or_publishing")
               for f in "${failed[@]}"; do
                 printf '##vso[task.logissue type=error;]failed signing or uploading:  %s\n' "$f"
               done
@@ -122,7 +122,7 @@ stages:
               MSG_DIR: "$(Pipeline.Workspace)/messages"
             displayName: Remove successful items from the queue
           - bash: |
-              readarray -t failed < <(jq -r '.[] | .content | fromjson.artifact.name' < "$MSG_DIR/failed_deleting_from_queue")
+              readarray -t failed < <(jq -r '.[] | .content | @base64d | fromjson.artifact.name' < "$MSG_DIR/failed_deleting_from_queue")
               for f in "${failed[@]}"; do
                 printf '##vso[task.logissue type=error;]failed removing from queue:  %s\n' "$f"
               done


### PR DESCRIPTION
There was a subtle bug in the error handling closure. The `err` variable from the environment was being captured and appended to the errs array. That variable was always nil, so no errors were being captured.

There was also a problem where the pipeline was improperly surfacing errors. This is because the payload is now base64 encoded. The surfacing code has been adjusted accordingly.