### PR TITLE
queue: dequeue all messages

### DIFF
--- a/queue_consumer.yaml
+++ b/queue_consumer.yaml
@@ -2,7 +2,7 @@ parameters:
   - name: num_messages
     displayName: number of messages to process
     type: string
-    default: "2147483647" # max 32-bit signed integer, i.e. all messages
+    default: "32" # max number of allowed messages
   - name: build_id
     displayName: build id
     type: string

--- a/queue_consumer.yaml
+++ b/queue_consumer.yaml
@@ -2,7 +2,7 @@ parameters:
   - name: num_messages
     displayName: number of messages to process
     type: string
-    default: "30"
+    default: "2147483647" # max 32-bit signed integer, i.e. all messages
   - name: build_id
     displayName: build id
     type: string


### PR DESCRIPTION
Otherwise, the deduplication-after-dequeue is flawed. If we only pull 30 messages, we are only resolving duplicates within those 30. We want to resolve all duplicates.