### PR TITLE
pipeline: don't publish tini when not building tini

### DIFF
--- a/cmd/push/main.go
+++ b/cmd/push/main.go
@@ -29,6 +29,7 @@ type Flags struct {
 	ArtifactDir string
 	BuildID     string
 	Debug       bool
+	PackageName string
 }
 
 const (
@@ -54,6 +55,7 @@ func perform() error {
 	f := Flags{}
 	flag.StringVar(&f.ArtifactDir, "artifact-dir", "", "path to directory of artifacts to upload")
 	flag.StringVar(&f.BuildID, "build-id", "", "build id")
+	flag.StringVar(&f.PackageName, "package-name", "", "package name")
 	flag.BoolVar(&f.Debug, "debug", false, "enable debug output")
 	flag.Parse()
 
@@ -225,7 +227,8 @@ func findBlobAndSpec(f Flags) (string, string, error) {
 			return nil
 		}
 
-		if r.MatchString(d.Name()) {
+		basename := d.Name()
+		if r.MatchString(basename) && strings.HasPrefix(basename, f.PackageName) {
 			blobFile = path
 			return nil
 		}

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -103,6 +103,7 @@ stages:
         steps:
           - download: current
             artifact: packages
+          # The following step can be removed once moby-tini is in PMC
           - script: |
               ! [ ${{ parameters.distro }} = mariner2 ] && exit 0
 
@@ -192,6 +193,13 @@ stages:
 
               make test OUTPUT="$bundle_dir"
             displayName: Integration Test
+          # The following step can be removed once moby-tini is in PMC
+          - bash: |
+              find "$BUNDLE_DIR" -type f -name 'moby-tini*' -print0 | xargs -0 rm -f
+            env:
+              BUNDLE_DIR: "$(Pipeline.Workspace)/packages"
+            condition: ne(parameters.package_name, 'moby-tini')
+            displayName: Remove manually-added moby-tini package
           - task: PublishBuildArtifacts@1
             inputs:
               pathToPublish: "$(Pipeline.Workspace)/packages"
@@ -221,7 +229,11 @@ stages:
               set -exu
               : ${BLOB_PREFIX:=/}
 
-              go run ./cmd/push --artifact-dir="$ARTIFACTS_DIR" --build-id="${{ parameters.build_id }}"
+              go run ./cmd/push \
+                --artifact-dir="$ARTIFACTS_DIR" \
+                --package-name="$PACKAGE_NAME" \
+                --build-id="${{ parameters.build_id }}"
             env:
               ARTIFACTS_DIR: $(Pipeline.Workspace)/packages
+              PACKAGE_NAME: "${{ parameters.package_name }}"
             displayName: Upload to Staging, Queue Signing Job


### PR DESCRIPTION
There was a bug in the code. Because tini isn't in the package repos yet, we're installing it for tests (except when we're testing tini itself). This ends up getting published to the queue with a URI like `https://moby.blob.core.windows.net/1691424061-moby-trigger/moby-engine/24.0.5+azure/mariner2/linux_amd64/moby-tini-0.19.0-1.cm2.x86_64.rpm`.

This is leading to conflicts on the queue consumer side, since there are multiple versions of tini enqueued at the same time.