### PR TITLE
build: Fix output directory structure

### DIFF
--- a/cmd/pop/main.go
+++ b/cmd/pop/main.go
@@ -289,7 +289,7 @@ func runUpload(args uploadArgs) error {
 		version := fmt.Sprintf("%s+azure", message.Spec.Tag)
 		distro := message.Spec.Distro
 		pkgOS := message.Spec.OS()
-		sanitizedArch := strings.ReplaceAll(message.Spec.Arch, "/", "")
+		sanitizedArch := strings.ReplaceAll(message.Spec.Arch, "/", "_")
 
 		storagePath := fmt.Sprintf("%s/%s/%s/%s_%s/%s", pkg, version, distro, pkgOS, sanitizedArch, pkgBasename)
 

--- a/cmd/push/main.go
+++ b/cmd/push/main.go
@@ -99,7 +99,7 @@ func perform() error {
 	}
 
 	pkgOS := spec.OS()
-	sanitizedArch := strings.ReplaceAll(spec.Arch, "/", "")
+	sanitizedArch := strings.ReplaceAll(spec.Arch, "/", "_")
 	blobBasename := filepath.Base(blobFile)
 	specBasename := filepath.Base(specFile)
 	storagePathBlob := fmt.Sprintf("%s/%s+azure/%s/%s_%s/%s", spec.Pkg, spec.Tag, spec.Distro, pkgOS, sanitizedArch, blobBasename)

--- a/make.go
+++ b/make.go
@@ -55,7 +55,7 @@ func main() {
 		targetOS = "windows"
 	}
 
-	sanitizedArch := strings.ReplaceAll(spec.Arch, "/", "")
+	sanitizedArch := strings.ReplaceAll(spec.Arch, "/", "_")
 	subDir := fmt.Sprintf("%s_%s", targetOS, sanitizedArch)
 
 	if _, err := out.Export(ctx, filepath.Join(*outDir, spec.Distro, subDir)); err != nil {

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -198,7 +198,7 @@ stages:
               find "$BUNDLE_DIR" -type f -name 'moby-tini*' -print0 | xargs -0 rm -f
             env:
               BUNDLE_DIR: "$(Pipeline.Workspace)/packages"
-            condition: ne(parameters.package_name, 'moby-tini')
+            condition: ne('${{ parameters.package_name }}', 'moby-tini')
             displayName: Remove manually-added moby-tini package
           - task: PublishBuildArtifacts@1
             inputs:


### PR DESCRIPTION
The latest api determines the listed architecture by performing a series of transformations. For example, `linux_amd64` would be split by the `_` delimiter, with `"linux"` as the os, `"amd64"` as the architecture, and `null` as the variant. The variant is `null` because there is no third element when splitting by `_`.

However, when the directory containing the artifact is named `linux_armv7` (as the code prior to this commit did), then the variant will still be `null`, whereas we want the variant to be `"v7"`. The variant is used by the latest API to assemble the architecture listing.

Existing listings have been `"arm/v7"`, and this change will return consistency to the listed architecture of armv7 packages.