### PR TITLE
Prevent next stages from running when queue empty

### DIFF
--- a/queue_consumer.yaml
+++ b/queue_consumer.yaml
@@ -40,9 +40,18 @@ stages:
                 --visibility-timeout 1 \
                 --num-messages "$NUM_MESSAGES" |
                 tee "$MSG_DIR/message"
-
+            env:
+              NUM_MESSAGES: "${{ parameters.num_messages }}"
+              MSG_DIR: "$(Pipeline.Workspace)/messages"
+            displayName: Pull Messages from Queue
+            name: GetMessages
+          - task: PublishBuildArtifacts@1
+            inputs:
+              pathToPublish: "$(Pipeline.Workspace)/messages"
+              artifactName: messages
+          - bash: |
+              set -exu
               num_messages_found=$(jq 'length' < "$MSG_DIR/message")
-
               echo "##vso[task.setvariable variable=nummessages;isOutput=true]$num_messages_found"
 
               if [ $num_messages_found -ne 0 ]; then
@@ -50,7 +59,7 @@ stages:
               fi
 
               # otherwise, cancel the rest of this pipeline & log that there were no queue messages
-              echo "##vso[build.updatebuildnumber]${{ parameters.build_id }}.$(Rev:r).no.new.queue.messages"
+              echo "##vso[build.updatebuildnumber]$UPDATED_BUILD_NUMBER"
               echo "##[warning]no new queue messages"
 
               # just in case, to avoid token leaking
@@ -63,14 +72,9 @@ stages:
                 -d '{"status": "Cancelling"}' \
                 'https://dev.azure.com/AzureContainerUpstream/Moby/_apis/build/builds/$(Build.BuildId)?api-version=7.0'
             env:
-              NUM_MESSAGES: "${{ parameters.num_messages }}"
               MSG_DIR: "$(Pipeline.Workspace)/messages"
-            displayName: Pull Messages from Queue
-            name: GetMessages
-          - task: PublishBuildArtifacts@1
-            inputs:
-              pathToPublish: "$(Pipeline.Workspace)/messages"
-              artifactName: messages
+              UPDATED_BUILD_NUMBER: "${{ parameters.build_id }}.no.new.queue.messages"
+            displayName: "Cancel Build if there are no Messages"
   - stage: SignAndPublish
     dependsOn: ["ReadQueue"]
     jobs:

--- a/queue_consumer.yaml
+++ b/queue_consumer.yaml
@@ -30,7 +30,7 @@ stages:
         pool: $(build.pool)
         steps:
           - bash: |
-              set -exu
+              set -eu
               mkdir "$MSG_DIR"
               az login --identity
               az storage message get \
@@ -42,7 +42,26 @@ stages:
                 tee "$MSG_DIR/message"
 
               num_messages_found=$(jq 'length' < "$MSG_DIR/message")
+
               echo "##vso[task.setvariable variable=nummessages;isOutput=true]$num_messages_found"
+
+              if [ $num_messages_found -ne 0 ]; then
+                exit 0
+              fi
+
+              # otherwise, cancel the rest of this pipeline & log that there were no queue messages
+              echo "##vso[build.updatebuildnumber]${{ parameters.build_id }}.$(Rev:r).no.new.queue.messages"
+              echo "##[warning]no new queue messages"
+
+              # just in case, to avoid token leaking
+              set +x
+
+              # cancel the build
+              curl -L -X PATCH \
+                -H 'Authorization: Bearer $(System.AccessToken)' \
+                -H 'Content-Type: application/json' \
+                -d '{"status": "Cancelling"}' \
+                'https://dev.azure.com/AzureContainerUpstream/Moby/_apis/build/builds/$(Build.BuildId)?api-version=7.0'
             env:
               NUM_MESSAGES: "${{ parameters.num_messages }}"
               MSG_DIR: "$(Pipeline.Workspace)/messages"
@@ -62,7 +81,7 @@ stages:
           - download: current
             artifact: messages
           - bash: |
-              set -exu
+              set -eu
               # downloads all packages, puts them in out-dir, logs successful downloads to stdout (put in 'downloaded' file)
               go run ./cmd/pop download --out-dir="$OUT_DIR" --messages-file="$MSG_DIR/message" | tee "$MSG_DIR/downloaded"
             env:
@@ -89,6 +108,7 @@ stages:
             parameters:
               folderPath: "$(Pipeline.Workspace)/signed"
           - bash: |
+              set -eu
               # uploads signed files to prod bucket, removes unsigned / failed uploads, writes output to stdout
               go run ./cmd/pop upload \
                 --signed-dir="$SIGNED_DIR" \
@@ -120,7 +140,7 @@ stages:
           - download: current
             artifact: messages
           - bash: |
-              set -exu
+              set -eu
 
               # removes successfully signed & published artifacts from the queue
               go run ./cmd/pop fixup-queue \


### PR DESCRIPTION
Query the API to cancel the build. Set the buildnumber to note that there are no new messages (but retain build ID prefix).

This will prevent us from needing to manually approve or cancel when there are no messages to process.