### PR TITLE
Dequeue all messages

### DIFF
--- a/cmd/pop/main.go
+++ b/cmd/pop/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
@@ -191,15 +192,15 @@ func convertToRawMsgs(msgs []*azqueue.DequeuedMessage) ([]Envelope, error) {
 		}
 
 		if msg.ExpirationTime != nil {
-			e.ExpirationTime = msg.ExpirationTime.String()
+			e.ExpirationTime = msg.ExpirationTime.Format(time.RFC3339)
 		}
 
 		if msg.InsertionTime != nil {
-			e.InsertionTime = msg.InsertionTime.String()
+			e.InsertionTime = msg.InsertionTime.Format(time.RFC3339)
 		}
 
 		if msg.TimeNextVisible != nil {
-			e.TimeNextVisible = msg.TimeNextVisible.String()
+			e.TimeNextVisible = msg.TimeNextVisible.Format(time.RFC3339)
 		}
 
 		envelopes = append(envelopes, e)

--- a/cmd/pop/main.go
+++ b/cmd/pop/main.go
@@ -77,7 +77,7 @@ type fixupQueueArgs struct {
 
 func run() error {
 	if len(os.Args) < 2 {
-		return fmt.Errorf("available arguments are download, upload, and delete")
+		return fmt.Errorf("available arguments are get-messages, download, upload, and delete")
 	}
 
 	dlArgs := downloadArgs{}
@@ -96,6 +96,10 @@ func run() error {
 	fqArgs.messagesFile = messagesFile
 
 	switch os.Args[1] {
+	case "get-messages":
+		if err := getMessages(); err != nil {
+			return err
+		}
 	case "download":
 		if err := runDownload(dlArgs); err != nil {
 			return err
@@ -113,6 +117,95 @@ func run() error {
 	}
 
 	return nil
+}
+
+func getMessages() error {
+	ctx := context.Background()
+	q, err := queue.NewDefaultSignQueueClient()
+	if err != nil {
+		return err
+	}
+
+	msgs, err := q.GetAllMessages(ctx)
+	if err != nil {
+		if len(msgs.Messages) == 0 {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "##vso[task.logissue type=error;]errors getting messages: %s\n", err)
+	}
+
+	envelopes, err := convertToRawMsgs(msgs.Messages)
+	if err != nil {
+		if len(envelopes) == 0 {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "##vso[task.logissue type=error;]errors converting messages to raw messages: %s\n", err)
+	}
+
+	j, err := json.Marshal(&envelopes)
+	if err != nil {
+		return err
+	}
+
+	// Write to stdout
+	fmt.Println(string(j))
+
+	return nil
+}
+
+func convertToRawMsgs(msgs []*azqueue.DequeuedMessage) ([]Envelope, error) {
+	envelopes := []Envelope{}
+	var errs error
+
+	fail := func(collection *error, err error) {
+		*collection = errors.Join(*collection, err)
+	}
+
+	for _, msg := range msgs {
+		var e Envelope
+		if msg == nil {
+			fail(&errs, fmt.Errorf("nil message, skipping..."))
+			continue
+		}
+
+		if msg.MessageID == nil {
+			fail(&errs, fmt.Errorf("nil message ID, skipping..."))
+			continue
+		}
+		e.ID = *msg.MessageID
+
+		if msg.MessageText == nil {
+			fail(&errs, fmt.Errorf("nil message content, skipping..."))
+			continue
+		}
+		e.Content = *msg.MessageText
+
+		if msg.PopReceipt == nil {
+			fail(&errs, fmt.Errorf("nil message popReceipt, skipping"))
+			continue
+		}
+		e.PopReceipt = *msg.PopReceipt
+
+		if msg.DequeueCount != nil {
+			e.DequeueCount = int(*msg.DequeueCount)
+		}
+
+		if msg.ExpirationTime != nil {
+			e.ExpirationTime = msg.ExpirationTime.String()
+		}
+
+		if msg.InsertionTime != nil {
+			e.InsertionTime = msg.InsertionTime.String()
+		}
+
+		if msg.TimeNextVisible != nil {
+			e.TimeNextVisible = msg.TimeNextVisible.String()
+		}
+
+		envelopes = append(envelopes, e)
+	}
+
+	return envelopes, errs
 }
 
 func runDownload(args downloadArgs) error {

--- a/queue_consumer.yaml
+++ b/queue_consumer.yaml
@@ -67,7 +67,7 @@ stages:
                 'https://dev.azure.com/AzureContainerUpstream/Moby/_apis/build/builds/$(Build.BuildId)?api-version=7.0'
             env:
               MSG_DIR: "$(Pipeline.Workspace)/messages"
-              UPDATED_BUILD_NUMBER: "${{ parameters.build_id }}.no.new.queue.messages"
+              UPDATED_BUILD_NUMBER: "${{ replace(parameters.build_id, '__not_supplied', '$(Date:yyyyMMdd)') }}.no.new.queue.messages"
             displayName: "Cancel Build if there are no Messages"
   - stage: SignAndPublish
     dependsOn: ["ReadQueue"]

--- a/queue_consumer.yaml
+++ b/queue_consumer.yaml
@@ -67,7 +67,7 @@ stages:
                 'https://dev.azure.com/AzureContainerUpstream/Moby/_apis/build/builds/$(Build.BuildId)?api-version=7.0'
             env:
               MSG_DIR: "$(Pipeline.Workspace)/messages"
-              UPDATED_BUILD_NUMBER: "${{ replace(parameters.build_id, '__not_supplied', '$(Date:yyyyMMdd)') }}.no.new.queue.messages"
+              UPDATED_BUILD_NUMBER: "${{ parameters.build_id }}.no.new.queue.messages"
             displayName: "Cancel Build if there are no Messages"
   - stage: SignAndPublish
     dependsOn: ["ReadQueue"]

--- a/queue_consumer.yaml
+++ b/queue_consumer.yaml
@@ -30,18 +30,12 @@ stages:
         pool: $(build.pool)
         steps:
           - bash: |
-              set -eu
-              mkdir "$MSG_DIR"
+              set -exu
+
               az login --identity
-              az storage message get \
-                --auth-mode login \
-                --account-name moby \
-                --queue-name moby-packaging-signing-and-publishing \
-                --visibility-timeout 1 \
-                --num-messages "$NUM_MESSAGES" |
-                tee "$MSG_DIR/message"
+              mkdir "$MSG_DIR"
+              go run ./cmd/pop get-messages | tee "$MSG_DIR/message"
             env:
-              NUM_MESSAGES: "${{ parameters.num_messages }}"
               MSG_DIR: "$(Pipeline.Workspace)/messages"
             displayName: Pull Messages from Queue
             name: GetMessages


### PR DESCRIPTION
*relevant diff here:* https://github.com/Azure/moby-packaging/compare/skip_when_no_messages...dequeue_all_messages

*note* this PR is based on #96, and that PR should be merged first.

- Move message fetching to go program
- Fetch all messages before proceeding, instead of a batch of 32