### PR TITLE
Fix signing

### DIFF
--- a/queue_consumer.yaml
+++ b/queue_consumer.yaml
@@ -126,9 +126,33 @@ stages:
             inputs:
               packageType: sdk
               version: 2.2.207
+          - bash: |
+              set -exu
+
+              win_dir="$SIGNED_DIR/windows"
+              linux_dir="$SIGNED_DIR/linux"
+
+              mkdir -p "$win_dir" "$linux_dir"
+              find "$SIGNED_DIR" -maxdepth 1 -type f -name "*.zip" -exec mv {} "$win_dir" \;
+              find "$SIGNED_DIR" -maxdepth 1 -type f -not -name "*.zip" -exec mv {} "$linux_dir" \;
+            displayName: Separate windows and linux artifacts
+            env:
+              SIGNED_DIR: "$(Pipeline.Workspace)/signed"
           - template: templates/sign.steps.yml
             parameters:
-              folderPath: "$(Pipeline.Workspace)/signed"
+              rootDir: "$(Pipeline.Workspace)/signed"
+          - bash: |
+              set -exu
+
+              win_dir="$SIGNED_DIR/windows"
+              linux_dir="$SIGNED_DIR/linux"
+
+              mv "$win_dir/*" "$SIGNED_DIR"
+              mv "$linux_dir/*" "$SIGNED_DIR"
+              rm -rf "$win_dir" "$linux_dir"
+            displayName: Separate windows and linux artifacts
+            env:
+              SIGNED_DIR: "$(Pipeline.Workspace)/signed"
           - task: PublishBuildArtifacts@1
             inputs:
               pathToPublish: "$(Pipeline.Workspace)/signed"

--- a/templates/sign.steps.windows.yml
+++ b/templates/sign.steps.windows.yml
@@ -70,7 +70,7 @@ steps:
       ]
 - script: |
     set -o xtrace
-    for i in ${ARTIFACTS_DIR}/windows/*; do
+    for i in ${ARTIFACTS_DIR}/*; do
       zip_file="$(file ${i}/*.zip | cut -d: -f1)"
       if [ ! -f "${zip_file}" ]; then
         continue

--- a/templates/sign.steps.yml
+++ b/templates/sign.steps.yml
@@ -1,12 +1,12 @@
 parameters:
-  folderPath: ''
+  rootDir: ''
 
 steps:
 - template: sign.steps.windows.yml
   parameters:
-    folderPath: ${{ parameters.folderPath }}
+    folderPath: ${{ parameters.rootDir }}/windows
     pattern: '*.exe'
 - template: sign.steps.linux.yml
   parameters:
-    folderPath: ${{ parameters.folderPath }}
+    folderPath: ${{ parameters.rootDir }}/linux
     pattern: '*'


### PR DESCRIPTION
Signing was broken because
- windows files were getting signed by the linux signing service
- zip files weren't being properly repacked
- exe files weren't being deleted after zip files were repacked