### PR TITLE
Add conflict for docker-buildx-plugin

### DIFF
--- a/moby-buildx/mapping.go
+++ b/moby-buildx/mapping.go
@@ -55,6 +55,10 @@ var (
 		Conflicts: []string{
 			"docker-ce",
 			"docker-ee",
+			"docker-buildx-plugin",
+		},
+		Replaces: []string{
+			"docker-buildx-plugin",
 		},
 	}
 

--- a/targets/go.go
+++ b/targets/go.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	GoVersion     = "1.19.12"
+	GoVersion     = "1.20.7"
 	GoRef         = path.Join("mcr.microsoft.com/oss/go/microsoft/golang:" + GoVersion)
 	GoModCacheKey = "go-mod-cache"
 )


### PR DESCRIPTION
Also bumps go to 1.20 which is a new minimum requirement for buildx.