### PR TITLE
Add shim to min-versions.json

### DIFF
--- a/scripts/min-versions.json
+++ b/scripts/min-versions.json
@@ -1,6 +1,7 @@
 {
     "moby-runc": "1.0.0-0",
     "moby-containerd": "1.4.0-0",
+    "moby-containerd-shim-systemd": "0.1.0-0",
     "moby-cli": "20.10.0-0",
     "moby-engine": "20.10.0-0",
     "moby-buildx": "0.9.0-0",


### PR DESCRIPTION
This will create an index for `moby-containerd-shim-systemd` so that it can be queried via the PMC latest API.