### PR TITLE
Fix install scripts for debian-based packages

### DIFF
--- a/pkg/archive/deb.go
+++ b/pkg/archive/deb.go
@@ -141,29 +141,29 @@ func (d *DebPackager) installScript(script *InstallScript, c *dagger.Container) 
 
 	var templateStr, filename, flag string
 	switch script.When {
-	case PkgActionPostInstall, PkgActionUpgrade:
+	case PkgActionPostInstall:
 		filename = filenamePostInstall
 		flag = flagPostInstall
 		templateStr = `
-if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
-  {{ replace .Script "\n" "\n  " }}
-fi
+{{ replace .Script "\n" "\n  " }}
+            `
+	case PkgActionUpgrade:
+		filename = filenamePostUpgrade
+		flag = flagUpgrade
+		templateStr = `
+{{ replace .Script "\n" "\n  " }}
             `
 	case PkgActionPreRemoval:
 		filename = filenamePreRm
 		flag = flagPreRm
 		templateStr = `
-if [ "$1" = remove ]; then
-  {{ replace .Script "\n" "\n  " }}
-fi
+{{ replace .Script "\n" "\n  " }}
             `
 	case PkgActionPostRemoval:
 		filename = filenamePostRm
 		flag = flagPostRm
 		templateStr = `
-if [ "$1" = "purge" ]; then
-  {{ replace .Script "\n" "\n  " }}
-fi
+{{ replace .Script "\n" "\n  " }}
             `
 	default:
 		panic("unrecognized package action: " + fmt.Sprintf("%d", script.When))


### PR DESCRIPTION
There were two bugs fixed here.

1. The post-upgrade action was not being handled at all (it was grouped with the post-install action)
2. There was a subtle bug in our script template. Because `fpm` wraps postinstall scripts in a function, the references to `$1` in our generated templates will refer to the first argument of the wrapping function, and not the first argument of the script as intended. Because the logic of when to run the scripts is handled by fpm, we need not reference positional script arguments at all.