### PR TITLE
Fix test result upload

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -145,10 +145,10 @@ stages:
                 [ -f "$spec_file" ]
 
                 # runs the tests
-                set +x
+                set +e
                 go run ./cmd/run_tests --spec-file="$spec_file" --bundle-dir="$BUNDLE_DIR"
                 rc="$?"
-                set -x
+                set -e
 
                 out_dir="$(go run ./cmd/path dir --spec-file="$spec_file" --bundle-dir="$RESULTS_DIR")"
                 mkdir -p "$out_dir"


### PR DESCRIPTION
`+x` and `-x` were mistakenly being used in place of `+e` and `-e`. This results in suppressing command expansion, but still exits if the tests fail. We want to upload the test results in the event of test failures!