### PR TITLE
Bump go version to 1.21.1 for go container

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1 // indirect
 	github.com/Khan/genqlient v0.6.0 // indirect
+	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1 h1:WpB/QDNLpMw
 github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/Khan/genqlient v0.6.0 h1:Bwb1170ekuNIVIwTJEqvO8y7RxBxXu639VJOkKSrwAk=
 github.com/Khan/genqlient v0.6.0/go.mod h1:rvChwWVTqXhiapdhLDV4bp9tz/Xvtewwkon4DpWWCRM=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=

--- a/make.go
+++ b/make.go
@@ -93,7 +93,13 @@ func do(ctx context.Context, client *dagger.Client, cfg *archive.Spec) (*dagger.
 	}
 	platform := dagger.Platform(fmt.Sprintf("%s/%s", targetOs, cfg.Arch))
 
-	target, err := targets.GetTarget(ctx, cfg.Distro, client, platform)
+	getGoVersion, ok := targets.GetGoVersionForPackage[cfg.Pkg]
+	if !ok {
+		return nil, fmt.Errorf("unknown package: %q", cfg.Pkg)
+	}
+	goVersion := getGoVersion(cfg)
+
+	target, err := targets.GetTarget(ctx, cfg.Distro, client, platform, goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/moby-buildx/go_version.go
+++ b/moby-buildx/go_version.go
@@ -1,0 +1,10 @@
+package buildx
+
+import (
+	"github.com/Azure/moby-packaging/pkg/archive"
+	"github.com/Azure/moby-packaging/pkg/goversion"
+)
+
+func GoVersion(_ *archive.Spec) string {
+	return goversion.DefaultVersion
+}

--- a/moby-cli/go_version.go
+++ b/moby-cli/go_version.go
@@ -1,0 +1,10 @@
+package cli
+
+import (
+	"github.com/Azure/moby-packaging/pkg/archive"
+	"github.com/Azure/moby-packaging/pkg/goversion"
+)
+
+func GoVersion(_ *archive.Spec) string {
+	return goversion.DefaultVersion
+}

--- a/moby-compose/go_version.go
+++ b/moby-compose/go_version.go
@@ -1,0 +1,29 @@
+package compose
+
+import (
+	"github.com/Azure/moby-packaging/pkg/archive"
+	"github.com/Azure/moby-packaging/pkg/goversion"
+	"github.com/Masterminds/semver/v3"
+)
+
+const (
+	threshold = "2.22.0"
+)
+
+func GoVersion(s *archive.Spec) string {
+	v, err := semver.NewVersion(s.Tag)
+	if err != nil {
+		return goversion.DefaultVersion
+	}
+
+	t, err := semver.NewVersion(threshold)
+	if err != nil {
+		return goversion.DefaultVersion
+	}
+
+	if v.Compare(t) >= 0 { // if v >= t
+		return goversion.OneTwentyOne
+	}
+
+	return goversion.DefaultVersion
+}

--- a/moby-containerd-shim-systemd/go_version.go
+++ b/moby-containerd-shim-systemd/go_version.go
@@ -1,0 +1,10 @@
+package shim
+
+import (
+	"github.com/Azure/moby-packaging/pkg/archive"
+	"github.com/Azure/moby-packaging/pkg/goversion"
+)
+
+func GoVersion(_ *archive.Spec) string {
+	return goversion.DefaultVersion
+}

--- a/moby-containerd/go_version.go
+++ b/moby-containerd/go_version.go
@@ -1,0 +1,10 @@
+package containerd
+
+import (
+	"github.com/Azure/moby-packaging/pkg/archive"
+	"github.com/Azure/moby-packaging/pkg/goversion"
+)
+
+func GoVersion(_ *archive.Spec) string {
+	return goversion.DefaultVersion
+}

--- a/moby-engine/go_version.go
+++ b/moby-engine/go_version.go
@@ -1,0 +1,10 @@
+package engine
+
+import (
+	"github.com/Azure/moby-packaging/pkg/archive"
+	"github.com/Azure/moby-packaging/pkg/goversion"
+)
+
+func GoVersion(_ *archive.Spec) string {
+	return goversion.DefaultVersion
+}

--- a/moby-runc/go_version.go
+++ b/moby-runc/go_version.go
@@ -1,0 +1,10 @@
+package runc
+
+import (
+	"github.com/Azure/moby-packaging/pkg/archive"
+	"github.com/Azure/moby-packaging/pkg/goversion"
+)
+
+func GoVersion(_ *archive.Spec) string {
+	return goversion.DefaultVersion
+}

--- a/moby-tini/go_version.go
+++ b/moby-tini/go_version.go
@@ -1,0 +1,10 @@
+package tini
+
+import (
+	"github.com/Azure/moby-packaging/pkg/archive"
+	"github.com/Azure/moby-packaging/pkg/goversion"
+)
+
+func GoVersion(_ *archive.Spec) string {
+	return goversion.DefaultVersion
+}

--- a/moby-tini/mapping.go
+++ b/moby-tini/mapping.go
@@ -1,4 +1,4 @@
-package mobyinit
+package tini
 
 import "github.com/Azure/moby-packaging/pkg/archive"
 

--- a/pkg/goversion/version.go
+++ b/pkg/goversion/version.go
@@ -1,0 +1,6 @@
+package goversion
+
+const (
+	DefaultVersion = "1.20.8"
+	OneTwentyOne   = "1.21.1"
+)

--- a/targets/bionic.go
+++ b/targets/bionic.go
@@ -24,8 +24,7 @@ func Bionic(ctx context.Context, client *dagger.Client, platform dagger.Platform
 		return nil, err
 	}
 
-	t := &Target{client: client, c: c, platform: platform, name: "bionic", pkgKind: "deb", buildPlatform: buildPlatform}
-	t.goVersion = goVersion
+	t := &Target{client: client, c: c, platform: platform, name: "bionic", pkgKind: "deb", buildPlatform: buildPlatform, goVersion: goVersion}
 
 	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {

--- a/targets/bionic.go
+++ b/targets/bionic.go
@@ -14,7 +14,7 @@ var (
 	BionicAptLibCacheKey = "bionic-apt-lib-cache"
 )
 
-func Bionic(ctx context.Context, client *dagger.Client, platform dagger.Platform) (*Target, error) {
+func Bionic(ctx context.Context, client *dagger.Client, platform dagger.Platform, goVersion string) (*Target, error) {
 	client = client.Pipeline("bionic/" + string(platform))
 	c := client.Container(dagger.ContainerOpts{Platform: platform}).From(BionicRef)
 	c = apt.Install(c, client.CacheVolume(BionicAptCacheKey), client.CacheVolume(BionicAptLibCacheKey), BaseBionicPackages...)
@@ -25,7 +25,9 @@ func Bionic(ctx context.Context, client *dagger.Client, platform dagger.Platform
 	}
 
 	t := &Target{client: client, c: c, platform: platform, name: "bionic", pkgKind: "deb", buildPlatform: buildPlatform}
-	t, err = t.WithPlatformEnvs().InstallGo(ctx)
+	t.goVersion = goVersion
+
+	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/targets/bookworm.go
+++ b/targets/bookworm.go
@@ -24,8 +24,7 @@ func Bookworm(ctx context.Context, client *dagger.Client, platform dagger.Platfo
 		return nil, err
 	}
 
-	t := &Target{client: client, c: c, platform: platform, name: "bookworm", pkgKind: "deb", buildPlatform: buildPlatform}
-	t.goVersion = goVersion
+	t := &Target{client: client, c: c, platform: platform, name: "bookworm", pkgKind: "deb", buildPlatform: buildPlatform, goVersion: goVersion}
 
 	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {

--- a/targets/bookworm.go
+++ b/targets/bookworm.go
@@ -14,7 +14,7 @@ var (
 	BookwormAptLibCacheKey = "bookworm-apt-lib-cache"
 )
 
-func Bookworm(ctx context.Context, client *dagger.Client, platform dagger.Platform) (*Target, error) {
+func Bookworm(ctx context.Context, client *dagger.Client, platform dagger.Platform, goVersion string) (*Target, error) {
 	client = client.Pipeline("bookworm/" + string(platform))
 	c := client.Container(dagger.ContainerOpts{Platform: platform}).From(BookwormRef)
 	c = apt.Install(c, client.CacheVolume(BookwormAptCacheKey), client.CacheVolume(BookwormAptLibCacheKey), BaseDebPackages...)
@@ -25,7 +25,9 @@ func Bookworm(ctx context.Context, client *dagger.Client, platform dagger.Platfo
 	}
 
 	t := &Target{client: client, c: c, platform: platform, name: "bookworm", pkgKind: "deb", buildPlatform: buildPlatform}
-	t, err = t.WithPlatformEnvs().InstallGo(ctx)
+	t.goVersion = goVersion
+
+	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/targets/bullseye.go
+++ b/targets/bullseye.go
@@ -24,8 +24,7 @@ func Bullseye(ctx context.Context, client *dagger.Client, platform dagger.Platfo
 		return nil, err
 	}
 
-	t := &Target{client: client, c: c, platform: platform, name: "bullseye", pkgKind: "deb", buildPlatform: buildPlatform}
-	t.goVersion = goVersion
+	t := &Target{client: client, c: c, platform: platform, name: "bullseye", pkgKind: "deb", buildPlatform: buildPlatform, goVersion: goVersion}
 
 	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {

--- a/targets/bullseye.go
+++ b/targets/bullseye.go
@@ -14,7 +14,7 @@ var (
 	BullseyeAptLibCacheKey = "bullseye-apt-lib-cache"
 )
 
-func Bullseye(ctx context.Context, client *dagger.Client, platform dagger.Platform) (*Target, error) {
+func Bullseye(ctx context.Context, client *dagger.Client, platform dagger.Platform, goVersion string) (*Target, error) {
 	client = client.Pipeline("bullseye/" + string(platform))
 	c := client.Container(dagger.ContainerOpts{Platform: platform}).From(BullseyeRef)
 	c = apt.Install(c, client.CacheVolume(BullseyeAptCacheKey), client.CacheVolume(BullseyeAptLibCacheKey), BaseDebPackages...)
@@ -25,7 +25,9 @@ func Bullseye(ctx context.Context, client *dagger.Client, platform dagger.Platfo
 	}
 
 	t := &Target{client: client, c: c, platform: platform, name: "bullseye", pkgKind: "deb", buildPlatform: buildPlatform}
-	t, err = t.WithPlatformEnvs().InstallGo(ctx)
+	t.goVersion = goVersion
+
+	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/targets/buster.go
+++ b/targets/buster.go
@@ -24,8 +24,7 @@ func Buster(ctx context.Context, client *dagger.Client, platform dagger.Platform
 		return nil, err
 	}
 
-	t := &Target{client: client, c: c, platform: platform, name: "buster", pkgKind: "deb", buildPlatform: buildPlatform}
-	t.goVersion = goVersion
+	t := &Target{client: client, c: c, platform: platform, name: "buster", pkgKind: "deb", buildPlatform: buildPlatform, goVersion: goVersion}
 
 	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {

--- a/targets/buster.go
+++ b/targets/buster.go
@@ -14,7 +14,7 @@ var (
 	BusterAptLibCacheKey = "buster-apt-lib-cache"
 )
 
-func Buster(ctx context.Context, client *dagger.Client, platform dagger.Platform) (*Target, error) {
+func Buster(ctx context.Context, client *dagger.Client, platform dagger.Platform, goVersion string) (*Target, error) {
 	client = client.Pipeline("buster/" + string(platform))
 	c := client.Container(dagger.ContainerOpts{Platform: platform}).From(BusterRef)
 	c = apt.Install(c, client.CacheVolume(BusterAptCacheKey), client.CacheVolume(BusterAptLibCacheKey), BaseDebPackages...)
@@ -25,7 +25,9 @@ func Buster(ctx context.Context, client *dagger.Client, platform dagger.Platform
 	}
 
 	t := &Target{client: client, c: c, platform: platform, name: "buster", pkgKind: "deb", buildPlatform: buildPlatform}
-	t, err = t.WithPlatformEnvs().InstallGo(ctx)
+	t.goVersion = goVersion
+
+	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/targets/centos7.go
+++ b/targets/centos7.go
@@ -21,8 +21,7 @@ func Centos7(ctx context.Context, client *dagger.Client, platform dagger.Platfor
 		return nil, err
 	}
 
-	t := &Target{client: client, c: c, platform: platform, name: "centos7", pkgKind: "rpm", buildPlatform: buildPlatform}
-	t.goVersion = goVersion
+	t := &Target{client: client, c: c, platform: platform, name: "centos7", pkgKind: "rpm", buildPlatform: buildPlatform, goVersion: goVersion}
 
 	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {

--- a/targets/centos7.go
+++ b/targets/centos7.go
@@ -11,7 +11,7 @@ var (
 	Centos7Ref = path.Join(MirrorPrefix(), "centos:7")
 )
 
-func Centos7(ctx context.Context, client *dagger.Client, platform dagger.Platform) (*Target, error) {
+func Centos7(ctx context.Context, client *dagger.Client, platform dagger.Platform, goVersion string) (*Target, error) {
 	client = client.Pipeline("centos7/" + string(platform))
 	c := client.Container(dagger.ContainerOpts{Platform: platform}).From(Centos7Ref)
 	c = YumInstall(c, BaseRPMPackages...)
@@ -22,7 +22,9 @@ func Centos7(ctx context.Context, client *dagger.Client, platform dagger.Platfor
 	}
 
 	t := &Target{client: client, c: c, platform: platform, name: "centos7", pkgKind: "rpm", buildPlatform: buildPlatform}
-	t, err = t.WithPlatformEnvs().InstallGo(ctx)
+	t.goVersion = goVersion
+
+	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/targets/focal.go
+++ b/targets/focal.go
@@ -24,7 +24,7 @@ func Focal(ctx context.Context, client *dagger.Client, platform dagger.Platform,
 		return nil, err
 	}
 
-	t := &Target{client: client, c: c, platform: platform, name: "focal", pkgKind: "deb", buildPlatform: buildPlatform}
+	t := &Target{client: client, c: c, platform: platform, name: "focal", pkgKind: "deb", buildPlatform: buildPlatform, goVersion: goVersion}
 	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {
 		return nil, err

--- a/targets/focal.go
+++ b/targets/focal.go
@@ -14,7 +14,7 @@ var (
 	FocalAptLibCacheKey = "focal-apt-lib-cache"
 )
 
-func Focal(ctx context.Context, client *dagger.Client, platform dagger.Platform) (*Target, error) {
+func Focal(ctx context.Context, client *dagger.Client, platform dagger.Platform, goVersion string) (*Target, error) {
 	client = client.Pipeline("focal/" + string(platform))
 	c := client.Container(dagger.ContainerOpts{Platform: platform}).From(FocalRef)
 	c = apt.Install(c, client.CacheVolume(FocalAptCacheKey), client.CacheVolume(FocalAptLibCacheKey), BaseDebPackages...)
@@ -25,7 +25,7 @@ func Focal(ctx context.Context, client *dagger.Client, platform dagger.Platform)
 	}
 
 	t := &Target{client: client, c: c, platform: platform, name: "focal", pkgKind: "deb", buildPlatform: buildPlatform}
-	t, err = t.WithPlatformEnvs().InstallGo(ctx)
+	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/targets/go.go
+++ b/targets/go.go
@@ -39,5 +39,7 @@ func (t *Target) InstallGo(ctx context.Context, goVersion string) (*Target, erro
 	if err != nil {
 		return nil, err
 	}
+
+	t.goVersion = goVersion
 	return t.update(c), nil
 }

--- a/targets/go.go
+++ b/targets/go.go
@@ -3,19 +3,21 @@ package targets
 import (
 	"context"
 	"fmt"
-	"path"
 
 	"dagger.io/dagger"
 )
 
+const (
+	GoRepo = "mcr.microsoft.com/oss/go/microsoft/golang"
+)
+
 var (
-	GoVersion     = "1.20.8"
-	GoRef         = path.Join("mcr.microsoft.com/oss/go/microsoft/golang:" + GoVersion)
 	GoModCacheKey = "go-mod-cache"
 )
 
-func InstallGo(ctx context.Context, c *dagger.Container, modCache, buildCache *dagger.CacheVolume) (*dagger.Container, error) {
-	dir := c.From(GoRef).Directory("/usr/local/go")
+func InstallGo(ctx context.Context, c *dagger.Container, modCache, buildCache *dagger.CacheVolume, goVersion string) (*dagger.Container, error) {
+	goRef := fmt.Sprintf("%s:%s", GoRepo, goVersion)
+	dir := c.From(goRef).Directory("/usr/local/go")
 	pathEnv, err := c.EnvVariable(ctx, "PATH")
 	if err != nil {
 		return nil, fmt.Errorf("error getting PATH: %w", err)
@@ -32,8 +34,8 @@ func InstallGo(ctx context.Context, c *dagger.Container, modCache, buildCache *d
 		WithMountedCache("/go/pkg/mod", modCache), nil
 }
 
-func (t *Target) InstallGo(ctx context.Context) (*Target, error) {
-	c, err := InstallGo(ctx, t.c, t.client.CacheVolume(GoModCacheKey), t.client.CacheVolume(t.name+"-go-build-cache-"+string(t.platform)))
+func (t *Target) InstallGo(ctx context.Context, goVersion string) (*Target, error) {
+	c, err := InstallGo(ctx, t.c, t.client.CacheVolume(GoModCacheKey), t.client.CacheVolume(t.name+"-go-build-cache-"+string(t.platform)), goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/targets/jammy.go
+++ b/targets/jammy.go
@@ -14,7 +14,7 @@ var (
 	JammyAptLibCacheKey = "jammy-apt-lib-cache"
 )
 
-func Jammy(ctx context.Context, client *dagger.Client, platform dagger.Platform) (*Target, error) {
+func Jammy(ctx context.Context, client *dagger.Client, platform dagger.Platform, goVersion string) (*Target, error) {
 	client = client.Pipeline("jammy/" + string(platform))
 	c := client.Container(dagger.ContainerOpts{Platform: platform}).From(JammyRef)
 	c = apt.Install(c, client.CacheVolume(JammyAptCacheKey), client.CacheVolume(JammyAptLibCacheKey), BaseDebPackages...)
@@ -25,7 +25,9 @@ func Jammy(ctx context.Context, client *dagger.Client, platform dagger.Platform)
 	}
 
 	t := &Target{client: client, c: c, platform: platform, name: "jammy", pkgKind: "deb", buildPlatform: buildPlatform}
-	t, err = t.WithPlatformEnvs().InstallGo(ctx)
+	t.goVersion = goVersion
+
+	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/targets/jammy.go
+++ b/targets/jammy.go
@@ -24,8 +24,7 @@ func Jammy(ctx context.Context, client *dagger.Client, platform dagger.Platform,
 		return nil, err
 	}
 
-	t := &Target{client: client, c: c, platform: platform, name: "jammy", pkgKind: "deb", buildPlatform: buildPlatform}
-	t.goVersion = goVersion
+	t := &Target{client: client, c: c, platform: platform, name: "jammy", pkgKind: "deb", buildPlatform: buildPlatform, goVersion: goVersion}
 
 	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {

--- a/targets/mariner2.go
+++ b/targets/mariner2.go
@@ -9,7 +9,7 @@ import (
 
 const Mariner2Ref = "mcr.microsoft.com/cbl-mariner/base/core:2.0"
 
-func Mariner2(ctx context.Context, client *dagger.Client, platform dagger.Platform) (*Target, error) {
+func Mariner2(ctx context.Context, client *dagger.Client, platform dagger.Platform, goVersion string) (*Target, error) {
 	client = client.Pipeline("mariner2/" + string(platform))
 	c := client.Container(dagger.ContainerOpts{Platform: platform}).From(Mariner2Ref)
 	c = tdnf.Install(c, BaseMarinerPackages...)
@@ -20,7 +20,9 @@ func Mariner2(ctx context.Context, client *dagger.Client, platform dagger.Platfo
 	}
 
 	t := &Target{client: client, c: c, platform: platform, name: "mariner2", pkgKind: "rpm", buildPlatform: buildPlatform}
-	t, err = t.WithPlatformEnvs().InstallGo(ctx)
+	t.goVersion = goVersion
+
+	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/targets/mariner2.go
+++ b/targets/mariner2.go
@@ -19,8 +19,7 @@ func Mariner2(ctx context.Context, client *dagger.Client, platform dagger.Platfo
 		return nil, err
 	}
 
-	t := &Target{client: client, c: c, platform: platform, name: "mariner2", pkgKind: "rpm", buildPlatform: buildPlatform}
-	t.goVersion = goVersion
+	t := &Target{client: client, c: c, platform: platform, name: "mariner2", pkgKind: "rpm", buildPlatform: buildPlatform, goVersion: goVersion}
 
 	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {

--- a/targets/rhel8.go
+++ b/targets/rhel8.go
@@ -28,8 +28,7 @@ func Rhel8(ctx context.Context, client *dagger.Client, platform dagger.Platform,
 		return nil, err
 	}
 
-	t := &Target{client: client, c: c, platform: platform, name: "rhel8", pkgKind: "rpm", buildPlatform: buildPlatform}
-	t.goVersion = goVersion
+	t := &Target{client: client, c: c, platform: platform, name: "rhel8", pkgKind: "rpm", buildPlatform: buildPlatform, goVersion: goVersion}
 
 	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {

--- a/targets/rhel8.go
+++ b/targets/rhel8.go
@@ -11,7 +11,7 @@ var (
 	Rhel8Ref = path.Join(MirrorPrefix(), "almalinux:8")
 )
 
-func Rhel8(ctx context.Context, client *dagger.Client, platform dagger.Platform) (*Target, error) {
+func Rhel8(ctx context.Context, client *dagger.Client, platform dagger.Platform, goVersion string) (*Target, error) {
 	client = client.Pipeline("rhel8/" + string(platform))
 	c := client.Container(dagger.ContainerOpts{Platform: platform}).From(Rhel8Ref).
 		WithExec([]string{"bash", "-c", `
@@ -29,7 +29,9 @@ func Rhel8(ctx context.Context, client *dagger.Client, platform dagger.Platform)
 	}
 
 	t := &Target{client: client, c: c, platform: platform, name: "rhel8", pkgKind: "rpm", buildPlatform: buildPlatform}
-	t, err = t.WithPlatformEnvs().InstallGo(ctx)
+	t.goVersion = goVersion
+
+	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/targets/rhel9.go
+++ b/targets/rhel9.go
@@ -25,8 +25,7 @@ func Rhel9(ctx context.Context, client *dagger.Client, platform dagger.Platform,
 		return nil, err
 	}
 
-	t := &Target{client: client, c: c, platform: platform, name: "rhel9", pkgKind: "rpm", buildPlatform: buildPlatform}
-	t.goVersion = goVersion
+	t := &Target{client: client, c: c, platform: platform, name: "rhel9", pkgKind: "rpm", buildPlatform: buildPlatform, goVersion: goVersion}
 
 	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {

--- a/targets/rhel9.go
+++ b/targets/rhel9.go
@@ -11,7 +11,7 @@ var (
 	Rhel9Ref = path.Join(MirrorPrefix(), "almalinux:9")
 )
 
-func Rhel9(ctx context.Context, client *dagger.Client, platform dagger.Platform) (*Target, error) {
+func Rhel9(ctx context.Context, client *dagger.Client, platform dagger.Platform, goVersion string) (*Target, error) {
 	client = client.Pipeline("rhel9/" + string(platform))
 	c := client.Container(dagger.ContainerOpts{Platform: platform}).From(Rhel9Ref).
 		WithExec([]string{"bash", "-ec", `
@@ -26,7 +26,9 @@ func Rhel9(ctx context.Context, client *dagger.Client, platform dagger.Platform)
 	}
 
 	t := &Target{client: client, c: c, platform: platform, name: "rhel9", pkgKind: "rpm", buildPlatform: buildPlatform}
-	t, err = t.WithPlatformEnvs().InstallGo(ctx)
+	t.goVersion = goVersion
+
+	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/targets/target.go
+++ b/targets/target.go
@@ -39,7 +39,9 @@ type Target struct {
 }
 
 func (t *Target) update(c *dagger.Container) *Target {
-	return &Target{c: c, name: t.name, platform: t.platform, client: t.client, pkgKind: t.pkgKind}
+	tgt := *t
+	tgt.c = c
+	return &tgt
 }
 
 func MirrorPrefix() string {

--- a/targets/windows.go
+++ b/targets/windows.go
@@ -12,7 +12,7 @@ var (
 	WindowsRef = path.Join(MirrorPrefix(), "buildpack-deps:bullseye")
 )
 
-func Windows(ctx context.Context, client *dagger.Client, platform dagger.Platform) (*Target, error) {
+func Windows(ctx context.Context, client *dagger.Client, platform dagger.Platform, goVersion string) (*Target, error) {
 	client = client.Pipeline("windows/" + string(platform))
 
 	buildPlatform, err := client.DefaultPlatform(ctx)
@@ -25,7 +25,9 @@ func Windows(ctx context.Context, client *dagger.Client, platform dagger.Platfor
 	c = c.WithEnvVariable("GOOS", "windows")
 
 	t := &Target{client: client, c: c, platform: platform, name: "windows", pkgKind: "win", buildPlatform: buildPlatform}
-	t, err = t.WithPlatformEnvs().InstallGo(ctx)
+	t.goVersion = goVersion
+
+	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/targets/windows.go
+++ b/targets/windows.go
@@ -24,8 +24,7 @@ func Windows(ctx context.Context, client *dagger.Client, platform dagger.Platfor
 	c = apt.Install(c, client.CacheVolume("bullseye-apt-cache"), client.CacheVolume("bullseye-apt-lib-cache"), BaseWinPackages...)
 	c = c.WithEnvVariable("GOOS", "windows")
 
-	t := &Target{client: client, c: c, platform: platform, name: "windows", pkgKind: "win", buildPlatform: buildPlatform}
-	t.goVersion = goVersion
+	t := &Target{client: client, c: c, platform: platform, name: "windows", pkgKind: "win", buildPlatform: buildPlatform, goVersion: goVersion}
 
 	t, err = t.WithPlatformEnvs().InstallGo(ctx, goVersion)
 	if err != nil {


### PR DESCRIPTION
This is required for building moby-compose 2.22