### PR TITLE
Use PMC pipeline 'master' branch

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -274,7 +274,8 @@ stages:
               buildDefinition: 'pmc-sync'
               queueBuildForUserThatTriggeredBuild: true
               useSameSourceVersion: true
-              useSameBranch: true
+              useSameBranch: false
+              branchToUse: 'master'
               waitForQueuedBuildsToFinish: true
               waitForQueuedBuildsToFinishRefreshTime: '60'
               failTaskIfBuildsNotSuccessful: true

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -273,7 +273,7 @@ stages:
               definitionIsInCurrentTeamProject: true
               buildDefinition: 'pmc-sync'
               queueBuildForUserThatTriggeredBuild: true
-              useSameSourceVersion: true
+              useSameSourceVersion: false
               useSameBranch: false
               branchToUse: 'master'
               waitForQueuedBuildsToFinish: true


### PR DESCRIPTION
The PMC sync pipeline is in the `pipelines` repo, which has a `master` branch, not `main`.