### PR TITLE
buildx: use go1.21

### DIFF
--- a/moby-buildx/go_version.go
+++ b/moby-buildx/go_version.go
@@ -6,5 +6,5 @@ import (
 )
 
 func GoVersion(_ *archive.Spec) string {
-	return goversion.DefaultVersion
+	return goversion.OneTwentyOne
 }


### PR DESCRIPTION
This is now used upstream for v0.12.