### PR TITLE
Remove LimitNOFILE=infinity from engine unit file

### DIFF
--- a/moby-engine/systemd/docker.service
+++ b/moby-engine/systemd/docker.service
@@ -28,7 +28,6 @@ StartLimitInterval=60s
 
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
-LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
 


### PR DESCRIPTION
This was a change made upstream due to the value of `infinity` being too high for certain workloads + host kernels.
The way systemd sets up the defaults now are perfectly fine these days.