### PR TITLE
containerd: use the go module proxy

### DIFF
--- a/packages/moby-containerd/deb.mk
+++ b/packages/moby-containerd/deb.mk
@@ -1,10 +1,10 @@
 #!/usr/bin/make -f
 
 # circumvent a few problematic (for Debian) Go features inspired by dh-golang
-export GOPROXY := direct
 export GO111MODULE := on
 export GOFLAGS := -trimpath
 export GOGC := off
+
 .PHONY: deb _binaries _man
 
 SHELL := $(shell which bash)


### PR DESCRIPTION
Currently, containerd 1.6 is unbuildable without the module proxy due to the github.com/mitchellh/osext depdency being taken down from github. This dependency is a transient depdendency in containerd 1.6.