### PR TITLE
containerd: Also use go module proxy in the rpm build

### DIFF
--- a/packages/moby-containerd/rpm.mk
+++ b/packages/moby-containerd/rpm.mk
@@ -2,7 +2,6 @@
 .PHONY: rpm
 
 # circumvent a few problematic (for Debian) Go features inspired by dh-golang
-export GOPROXY := direct
 export GO111MODULE := on
 export GOFLAGS := -trimpath
 export GOGC := off


### PR DESCRIPTION
ref: https://github.com/containerd/containerd/issues/9969