### PR TITLE
Add support for building containerd 2.0

### DIFF
--- a/make.go
+++ b/make.go
@@ -103,6 +103,5 @@ func do(ctx context.Context, client *dagger.Client, cfg *archive.Spec) (*dagger.
 	if err != nil {
 		return nil, err
 	}
-	out := target.Make(cfg, packageDir(client, cfg.Pkg), hackCrossDir(client))
-	return out, nil
+	return target.Make(cfg, packageDir(client, cfg.Pkg), hackCrossDir(client))
 }

--- a/packages/moby-compose/go_version.go
+++ b/packages/moby-compose/go_version.go
@@ -1,6 +1,8 @@
 package compose
 
 import (
+	"strings"
+
 	"github.com/Azure/moby-packaging/pkg/archive"
 	"github.com/Azure/moby-packaging/pkg/goversion"
 	"github.com/Masterminds/semver/v3"
@@ -11,7 +13,9 @@ const (
 )
 
 func GoVersion(s *archive.Spec) string {
-	v, err := semver.NewVersion(s.Tag)
+	tag, _, _ := strings.Cut(s.Tag, "~")
+
+	v, err := semver.NewVersion(tag)
 	if err != nil {
 		return goversion.DefaultVersion
 	}

--- a/packages/moby-containerd/mapping.go
+++ b/packages/moby-containerd/mapping.go
@@ -2,8 +2,11 @@ package containerd
 
 import (
 	_ "embed"
+	"fmt"
+	"strings"
 
 	"github.com/Azure/moby-packaging/pkg/archive"
+	"github.com/Masterminds/semver/v3"
 )
 
 var (
@@ -20,141 +23,23 @@ var (
 	rpmPreRm string
 	//go:embed postinstall/rpm/upgrade
 	rpmUpgrade string
-
-	Archives = map[string]archive.Archive{
-		"bookworm": DebArchive,
-		"buster":   DebArchive,
-		"bullseye": DebArchive,
-		"bionic":   DebArchive,
-		"focal":    DebArchive,
-		"centos7":  RPMArchive,
-		"rhel8":    RPMArchive,
-		"rhel9":    RPMArchive,
-		"windows":  BaseArchive,
-		"jammy":    DebArchive,
-		"mariner2": MarinerArchive,
-	}
-
-	BaseArchive = archive.Archive{
-		Name:    "moby-containerd",
-		Webpage: "https://github.com/containerd/containerd",
-		Files: []archive.File{
-			{Source: "/build/src/bin", Dest: "usr/bin"},
-			{Source: "/build/man", Dest: "/usr/share/man"},
-			{Source: "/build/legal/LICENSE", Dest: "/usr/share/doc/moby-containerd/LICENSE"},
-			{Source: "/build/legal/NOTICE", Dest: "/usr/share/doc/moby-containerd/NOTICE.gz", Compress: true},
-		},
-		Systemd: []archive.Systemd{
-			{Source: "/build/src/containerd.service", Dest: "lib/systemd/system/containerd.service"},
-		},
-		Binaries: []string{
-			"/build/src/bin/containerd",
-			"/build/src/bin/containerd-shim",
-			"/build/src/bin/containerd-shim-runc-v1",
-			"/build/src/bin/containerd-shim-runc-v2",
-			"/build/src/bin/containerd-stress",
-		},
-		WinBinaries: []string{
-			"/build/src/bin/containerd.exe",
-			"/build/src/bin/containerd-shim-runhcs-v1.exe",
-			"/build/src/bin/ctr.exe",
-		},
-		Description: `Industry-standard container runtime
- containerd is an industry-standard container runtime with an emphasis on
- simplicity, robustness and portability. It is available as a daemon for Linux
- and Windows, which can manage the complete container lifecycle of its host
- system: image transfer and storage, container execution and supervision,
- low-level storage and network attachments, etc.
- .
- containerd is designed to be embedded into a larger system, rather than being
- used directly by developers or end-users.`,
-	}
-
-	DebArchive = archive.Archive{
-		Name:    BaseArchive.Name,
-		Webpage: BaseArchive.Webpage,
-		Files:   BaseArchive.Files,
-		Systemd: BaseArchive.Systemd,
-		Binaries: []string{
-			"/build/src/bin/containerd",
-			"/build/src/bin/containerd-shim",
-			"/build/src/bin/containerd-shim-runc-v1",
-			"/build/src/bin/containerd-shim-runc-v2",
-			"/build/src/bin/containerd-stress",
-		},
-		RuntimeDeps: []string{
-			"moby-runc (>= 1.0.2)",
-		},
-		Recommends: []string{
-			"ca-certificates",
-		},
-		Conflicts: []string{
-			"containerd", "containerd.io", "moby-engine (<= 3.0.12)",
-		},
-		Replaces: []string{
-			"containerd", "containerd.io",
-		},
-		Provides: []string{
-			"containerd", "containerd.io",
-		},
-		InstallScripts: []archive.InstallScript{
-			{When: archive.PkgActionPostInstall, Script: debPostInstall},
-			{When: archive.PkgActionPreRemoval, Script: debPreRm},
-			{When: archive.PkgActionPostRemoval, Script: debPostRm},
-		},
-		Description: BaseArchive.Description,
-	}
-
-	RPMArchive = archive.Archive{
-		Name:    BaseArchive.Name,
-		Webpage: BaseArchive.Webpage,
-		Files:   BaseArchive.Files,
-		Systemd: BaseArchive.Systemd,
-		Binaries: []string{
-			"/build/src/bin/containerd",
-			"/build/src/bin/containerd-shim",
-			"/build/src/bin/containerd-shim-runc-v1",
-			"/build/src/bin/containerd-shim-runc-v2",
-			"/build/src/bin/containerd-stress",
-		},
-		RuntimeDeps: []string{
-			"/bin/sh",
-			"container-selinux >= 2:2.95",
-			"device-mapper-libs >= 1.02.90-1",
-			"iptables",
-			"libcgroup",
-			"libseccomp >= 2.3",
-			"moby-containerd >= 1.3.9",
-			"moby-runc >= 1.0.2",
-			"systemd-units",
-			"tar",
-			"xz",
-		},
-		Conflicts: []string{
-			"containerd", "containerd-io", "moby-engine <= 3.0.11",
-		},
-		InstallScripts: []archive.InstallScript{
-			{When: archive.PkgActionPostInstall, Script: rpmPostInstall},
-			{When: archive.PkgActionPreRemoval, Script: rpmPreRm},
-			{When: archive.PkgActionUpgrade, Script: rpmUpgrade},
-		},
-		Description: BaseArchive.Description,
-	}
-
-	MarinerArchive = func() archive.Archive {
-		m := RPMArchive
-		m.RuntimeDeps = []string{
-			"/bin/sh",
-			"device-mapper-libs >= 1.02.90-1",
-			"iptables",
-			"libcgroup",
-			"libseccomp >= 2.3",
-			"moby-containerd >= 1.3.9",
-			"moby-runc >= 1.0.2",
-			"systemd-units",
-			"tar",
-			"xz",
-		}
-		return m
-	}()
 )
+
+func Archives(version string) (map[string]archive.Archive, error) {
+	// We use `~` in packaging to indicate that the version is a pre-release version.
+	// semver does not recognize `~`.
+	// We only really care about major/minor version here, so we can just cut off the pre-release part.
+	version, _, _ = strings.Cut(version, "~")
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return nil, fmt.Errorf("invalid version: %s: %w", version, err)
+	}
+	switch fmt.Sprintf("%d.%d", v.Major(), v.Minor()) {
+	case "1.6", "1.7":
+		return Archives_1_X, nil
+	case "2.0":
+		return Archives_2_0, nil
+	default:
+		return nil, fmt.Errorf("unsupported version: %s", version)
+	}
+}

--- a/packages/moby-containerd/mapping_1_6.go
+++ b/packages/moby-containerd/mapping_1_6.go
@@ -1,0 +1,135 @@
+package containerd
+
+import (
+	_ "embed"
+
+	"github.com/Azure/moby-packaging/pkg/archive"
+)
+
+var (
+	Archives_1_X = map[string]archive.Archive{
+		"bookworm": DebArchive_1_X,
+		"buster":   DebArchive_1_X,
+		"bullseye": DebArchive_1_X,
+		"bionic":   DebArchive_1_X,
+		"focal":    DebArchive_1_X,
+		"centos7":  RPMArchive_1_X,
+		"rhel8":    RPMArchive_1_X,
+		"rhel9":    RPMArchive_1_X,
+		"windows":  BaseArchive_1_X,
+		"jammy":    RPMArchive_1_X,
+		"mariner2": MarinerArchive_1_X,
+	}
+
+	BaseArchive_1_X = archive.Archive{
+		Name:    "moby-containerd",
+		Webpage: "https://github.com/containerd/containerd",
+		Files: []archive.File{
+			{Source: "/build/src/bin", Dest: "usr/bin"},
+			{Source: "/build/man", Dest: "/usr/share/man"},
+			{Source: "/build/legal/LICENSE", Dest: "/usr/share/doc/moby-containerd/LICENSE"},
+			{Source: "/build/legal/NOTICE", Dest: "/usr/share/doc/moby-containerd/NOTICE.gz", Compress: true},
+		},
+		Systemd: []archive.Systemd{
+			{Source: "/build/src/containerd.service", Dest: "lib/systemd/system/containerd.service"},
+		},
+		Binaries: []string{
+			"/build/src/bin/containerd",
+			"/build/src/bin/ctr",
+			"/build/src/bin/containerd-shim",
+			"/build/src/bin/containerd-shim-runc-v1",
+			"/build/src/bin/containerd-shim-runc-v2",
+			"/build/src/bin/containerd-stress",
+		},
+		WinBinaries: []string{
+			"/build/src/bin/containerd.exe",
+			"/build/src/bin/containerd-shim-runhcs-v1.exe",
+			"/build/src/bin/ctr.exe",
+		},
+		Description: `Industry-standard container runtime
+ containerd is an industry-standard container runtime with an emphasis on
+ simplicity, robustness and portability. It is available as a daemon for Linux
+ and Windows, which can manage the complete container lifecycle of its host
+ system: image transfer and storage, container execution and supervision,
+ low-level storage and network attachments, etc.
+ .
+ containerd is designed to be embedded into a larger system, rather than being
+ used directly by developers or end-users.`,
+	}
+
+	DebArchive_1_X = archive.Archive{
+		Name:     BaseArchive_1_X.Name,
+		Webpage:  BaseArchive_1_X.Webpage,
+		Files:    BaseArchive_1_X.Files,
+		Systemd:  BaseArchive_1_X.Systemd,
+		Binaries: BaseArchive_1_X.Binaries,
+		RuntimeDeps: []string{
+			"moby-runc (>= 1.0.2)",
+		},
+		Recommends: []string{
+			"ca-certificates",
+		},
+		Conflicts: []string{
+			"containerd", "containerd.io", "moby-engine (<= 3.0.12)",
+		},
+		Replaces: []string{
+			"containerd", "containerd.io",
+		},
+		Provides: []string{
+			"containerd", "containerd.io",
+		},
+		InstallScripts: []archive.InstallScript{
+			{When: archive.PkgActionPostInstall, Script: debPostInstall},
+			{When: archive.PkgActionPreRemoval, Script: debPreRm},
+			{When: archive.PkgActionPostRemoval, Script: debPostRm},
+		},
+		Description: BaseArchive_1_X.Description,
+	}
+
+	RPMArchive_1_X = archive.Archive{
+		Name:     BaseArchive_1_X.Name,
+		Webpage:  BaseArchive_1_X.Webpage,
+		Files:    BaseArchive_1_X.Files,
+		Systemd:  BaseArchive_1_X.Systemd,
+		Binaries: BaseArchive_1_X.Binaries,
+		RuntimeDeps: []string{
+			"/bin/sh",
+			"container-selinux >= 2:2.95",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"libseccomp >= 2.3",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		},
+		Conflicts: []string{
+			"containerd", "containerd-io", "moby-engine <= 3.0.11",
+		},
+		InstallScripts: []archive.InstallScript{
+			{When: archive.PkgActionPostInstall, Script: rpmPostInstall},
+			{When: archive.PkgActionPreRemoval, Script: rpmPreRm},
+			{When: archive.PkgActionUpgrade, Script: rpmUpgrade},
+		},
+		Description: BaseArchive_1_X.Description,
+	}
+
+	MarinerArchive_1_X = func() archive.Archive {
+		m := RPMArchive_1_X
+		m.RuntimeDeps = []string{
+			"/bin/sh",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"libseccomp >= 2.3",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		}
+		return m
+	}()
+)

--- a/packages/moby-containerd/mapping_2_0.go
+++ b/packages/moby-containerd/mapping_2_0.go
@@ -1,0 +1,132 @@
+package containerd
+
+import (
+	_ "embed"
+
+	"github.com/Azure/moby-packaging/pkg/archive"
+)
+
+var (
+	Archives_2_0 = map[string]archive.Archive{
+		"bookworm": DebArchive_2_0,
+		"buster":   DebArchive_2_0,
+		"bullseye": DebArchive_2_0,
+		"bionic":   DebArchive_2_0,
+		"focal":    DebArchive_2_0,
+		"centos7":  RPMArchive_2_0,
+		"rhel8":    RPMArchive_2_0,
+		"rhel9":    RPMArchive_2_0,
+		"windows":  BaseArchive_2_0,
+		"jammy":    DebArchive_2_0,
+		"mariner2": MarinerArchive_2_0,
+	}
+
+	BaseArchive_2_0 = archive.Archive{
+		Name:    "moby-containerd",
+		Webpage: "https://github.com/containerd/containerd",
+		Files: []archive.File{
+			{Source: "/build/src/bin", Dest: "usr/bin"},
+			{Source: "/build/man", Dest: "/usr/share/man"},
+			{Source: "/build/legal/LICENSE", Dest: "/usr/share/doc/moby-containerd/LICENSE"},
+			{Source: "/build/legal/NOTICE", Dest: "/usr/share/doc/moby-containerd/NOTICE.gz", Compress: true},
+		},
+		Systemd: []archive.Systemd{
+			{Source: "/build/src/containerd.service", Dest: "lib/systemd/system/containerd.service"},
+		},
+		Binaries: []string{
+			"/build/src/bin/containerd",
+			"/build/src/bin/containerd-shim-runc-v2",
+			"/build/src/bin/ctr",
+		},
+		WinBinaries: []string{
+			"/build/src/bin/containerd.exe",
+			"/build/src/bin/containerd-shim-runhcs-v1.exe",
+			"/build/src/bin/ctr.exe",
+		},
+		Description: `Industry-standard container runtime
+ containerd is an industry-standard container runtime with an emphasis on
+ simplicity, robustness and portability. It is available as a daemon for Linux
+ and Windows, which can manage the complete container lifecycle of its host
+ system: image transfer and storage, container execution and supervision,
+ low-level storage and network attachments, etc.
+ .
+ containerd is designed to be embedded into a larger system, rather than being
+ used directly by developers or end-users.`,
+	}
+
+	DebArchive_2_0 = archive.Archive{
+		Name:     BaseArchive_2_0.Name,
+		Webpage:  BaseArchive_2_0.Webpage,
+		Files:    BaseArchive_2_0.Files,
+		Systemd:  BaseArchive_2_0.Systemd,
+		Binaries: BaseArchive_2_0.Binaries,
+		RuntimeDeps: []string{
+			"moby-runc (>= 1.0.2)",
+		},
+		Recommends: []string{
+			"ca-certificates",
+		},
+		Conflicts: []string{
+			"containerd", "containerd.io", "moby-engine (<= 3.0.12)",
+		},
+		Replaces: []string{
+			"containerd", "containerd.io",
+		},
+		Provides: []string{
+			"containerd", "containerd.io",
+		},
+		InstallScripts: []archive.InstallScript{
+			{When: archive.PkgActionPostInstall, Script: debPostInstall},
+			{When: archive.PkgActionPreRemoval, Script: debPreRm},
+			{When: archive.PkgActionPostRemoval, Script: debPostRm},
+		},
+		Description: BaseArchive_2_0.Description,
+	}
+
+	RPMArchive_2_0 = archive.Archive{
+		Name:     BaseArchive_2_0.Name,
+		Webpage:  BaseArchive_2_0.Webpage,
+		Files:    BaseArchive_2_0.Files,
+		Systemd:  BaseArchive_2_0.Systemd,
+		Binaries: BaseArchive_1_X.Binaries,
+		RuntimeDeps: []string{
+			"/bin/sh",
+			"container-selinux >= 2:2.95",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"libseccomp >= 2.3",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		},
+		Conflicts: []string{
+			"containerd", "containerd-io", "moby-engine <= 3.0.11",
+		},
+		InstallScripts: []archive.InstallScript{
+			{When: archive.PkgActionPostInstall, Script: rpmPostInstall},
+			{When: archive.PkgActionPreRemoval, Script: rpmPreRm},
+			{When: archive.PkgActionUpgrade, Script: rpmUpgrade},
+		},
+		Description: BaseArchive_2_0.Description,
+	}
+
+	MarinerArchive_2_0 = func() archive.Archive {
+		m := RPMArchive_2_0
+		m.RuntimeDeps = []string{
+			"/bin/sh",
+			"device-mapper-libs >= 1.02.90-1",
+			"iptables",
+			"libcgroup",
+			"libseccomp >= 2.3",
+			"moby-containerd >= 1.3.9",
+			"moby-runc >= 1.0.2",
+			"systemd-units",
+			"tar",
+			"xz",
+		}
+		return m
+	}()
+)


### PR DESCRIPTION
The main difference here is 2.0 drops support for the v1 shim (`containerd-shim` and `containerd-shim-runc-v1`) binaries. But we still need to support building 1.x packages for now so this splits those up into "archives".
When building we do a switch on the version tag to determine which set of archives to use.