### PR TITLE
Bump go to 1.21.9

### DIFF
--- a/pkg/goversion/version.go
+++ b/pkg/goversion/version.go
@@ -2,5 +2,5 @@ package goversion
 
 const (
 	DefaultVersion = OneTwentyOne
-	OneTwentyOne   = "1.21.8"
+	OneTwentyOne   = "1.21.9"
 )


### PR DESCRIPTION
This addresses a CVE in go.