### PR TITLE
containerd: Fix incorrect archive reference for 1.x builds

### DIFF
--- a/packages/moby-containerd/mapping_1_6.go
+++ b/packages/moby-containerd/mapping_1_6.go
@@ -13,12 +13,12 @@ var (
 		"bullseye": DebArchive_1_X,
 		"bionic":   DebArchive_1_X,
 		"focal":    DebArchive_1_X,
+		"jammy":    DebArchive_1_X,
 		"centos7":  RPMArchive_1_X,
 		"rhel8":    RPMArchive_1_X,
 		"rhel9":    RPMArchive_1_X,
-		"windows":  BaseArchive_1_X,
-		"jammy":    RPMArchive_1_X,
 		"mariner2": MarinerArchive_1_X,
+		"windows":  BaseArchive_1_X,
 	}
 
 	BaseArchive_1_X = archive.Archive{

--- a/packages/moby-containerd/mapping_2_0.go
+++ b/packages/moby-containerd/mapping_2_0.go
@@ -13,12 +13,12 @@ var (
 		"bullseye": DebArchive_2_0,
 		"bionic":   DebArchive_2_0,
 		"focal":    DebArchive_2_0,
+		"jammy":    DebArchive_2_0,
 		"centos7":  RPMArchive_2_0,
 		"rhel8":    RPMArchive_2_0,
 		"rhel9":    RPMArchive_2_0,
-		"windows":  BaseArchive_2_0,
-		"jammy":    DebArchive_2_0,
 		"mariner2": MarinerArchive_2_0,
+		"windows":  BaseArchive_2_0,
 	}
 
 	BaseArchive_2_0 = archive.Archive{


### PR DESCRIPTION
This was caused by a bad copy/paste when adding the 2.0 builds. Fixed the problem and also moved jammy up with the rest of the ubuntu versions so they are better grouped.