### PR TITLE
Bump go version to 1.21.10

### DIFF
--- a/pkg/goversion/version.go
+++ b/pkg/goversion/version.go
@@ -2,5 +2,5 @@ package goversion
 
 const (
 	DefaultVersion = OneTwentyOne
-	OneTwentyOne   = "1.21.9"
+	OneTwentyOne   = "1.21.10"
 )


### PR DESCRIPTION
This addresses multiple CVE's in go.