### PR TITLE
Bump go

### DIFF
--- a/packages/moby-containerd/go_version.go
+++ b/packages/moby-containerd/go_version.go
@@ -3,8 +3,18 @@ package containerd
 import (
 	"github.com/Azure/moby-packaging/pkg/archive"
 	"github.com/Azure/moby-packaging/pkg/goversion"
+	"github.com/Masterminds/semver/v3"
 )
 
-func GoVersion(_ *archive.Spec) string {
-	return goversion.DefaultVersion
+func GoVersion(spec *archive.Spec) string {
+	v, err := semver.NewVersion(spec.Tag)
+	if err != nil {
+		panic(err)
+	}
+
+	if v.Major() < 2 {
+		return goversion.OneTwentyOne
+	} else {
+		return goversion.OneTwentyTwo
+	}
 }

--- a/pkg/goversion/version.go
+++ b/pkg/goversion/version.go
@@ -2,5 +2,5 @@ package goversion
 
 const (
 	DefaultVersion = OneTwentyOne
-	OneTwentyOne   = "1.21.10"
+	OneTwentyOne   = "1.21.11"
 )

--- a/pkg/goversion/version.go
+++ b/pkg/goversion/version.go
@@ -3,4 +3,5 @@ package goversion
 const (
 	DefaultVersion = OneTwentyOne
 	OneTwentyOne   = "1.21.11"
+	OneTwentyTwo   = "1.22.4"
 )


### PR DESCRIPTION
- Update to go1.21.4
- Bump containerd 2.0 to use go1.22 (which is required)