### PR TITLE
Fix go version switch for containerd

### DIFF
--- a/packages/moby-containerd/go_version.go
+++ b/packages/moby-containerd/go_version.go
@@ -1,13 +1,16 @@
 package containerd
 
 import (
+	"strings"
+
 	"github.com/Azure/moby-packaging/pkg/archive"
 	"github.com/Azure/moby-packaging/pkg/goversion"
 	"github.com/Masterminds/semver/v3"
 )
 
 func GoVersion(spec *archive.Spec) string {
-	v, err := semver.NewVersion(spec.Tag)
+	version, _, _ := strings.Cut(spec.Tag, "~")
+	v, err := semver.NewVersion(version)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
I tested this using a different version format than what we actually use in our builds.
Since the tag field is used for package versions, the version is not semver compatible due to the use of `~` for prerelease versions.

This just drops the tilde and everything after since this is not something we care about when checking the version.