### PR TITLE
runc: fix how version is set after upstream change

### DIFF
--- a/cmd/run_tests/main.go
+++ b/cmd/run_tests/main.go
@@ -59,6 +59,8 @@ func runTest(args Args) error {
 		return fmt.Errorf("unrecognized distro: %s", pkgOs)
 	}
 
+	fmt.Fprintf(os.Stderr, "%+v\n%s", s, pv)
+
 	fmt.Printf(`
 DISTRO=%[1]s
 TARGETARCH=%[2]s

--- a/packages/moby-runc/deb.mk
+++ b/packages/moby-runc/deb.mk
@@ -2,8 +2,7 @@ deb: runc man/man8
 
 runc:
 	cd src && \
-	echo $(VERSION)-$(REVISION) > VERSION && \
-	$(MAKE) runc BUILDTAGS='seccomp'
+	$(MAKE) runc BUILDTAGS='seccomp' VERSION="${VERSION}-${REVISION}"
 
 man/man8:
 	cd src && \


### PR DESCRIPTION
Upstream changed how the binary version can be set which broke how we were setting it.
Now we can pass a VERSION env var into runcs make file to have it use that instead of modifying the VERSION file in the repo.

Because we already have a VERSION field set in the env, the runc makefile is taking that, but it does not contain the revision number, so we need to modify that env.

Upstream change that broke this is https://github.com/opencontainers/runc/pull/4270