### PR TITLE
runc: fix runc version for rpms

### DIFF
--- a/packages/moby-runc/rpm.mk
+++ b/packages/moby-runc/rpm.mk
@@ -3,8 +3,7 @@ rpm: runc man/man8
 
 runc:
 	cd src && \
-	echo $(VERSION)-$(REVISION) > VERSION && \
-	$(MAKE) runc BUILDTAGS='seccomp'
+	$(MAKE) runc BUILDTAGS='seccomp' VERSION="${VERSION}-${REVISION}"
 
 man/man8:
 	cd src && \


### PR DESCRIPTION
The last fix only did debs (oops).
This takes care of it for rpms.