### PR TITLE
Bump go versions

### DIFF
--- a/packages/moby-buildx/go_version.go
+++ b/packages/moby-buildx/go_version.go
@@ -6,5 +6,5 @@ import (
 )
 
 func GoVersion(_ *archive.Spec) string {
-	return goversion.OneTwentyOne
+	return goversion.OneTwentyTwo
 }

--- a/packages/moby-compose/go_version.go
+++ b/packages/moby-compose/go_version.go
@@ -26,7 +26,7 @@ func GoVersion(s *archive.Spec) string {
 	}
 
 	if v.Compare(t) >= 0 { // if v >= t
-		return goversion.OneTwentyOne
+		return goversion.OneTwentyThree
 	}
 
 	return goversion.DefaultVersion

--- a/packages/moby-containerd/go_version.go
+++ b/packages/moby-containerd/go_version.go
@@ -1,23 +1,10 @@
 package containerd
 
 import (
-	"strings"
-
 	"github.com/Azure/moby-packaging/pkg/archive"
 	"github.com/Azure/moby-packaging/pkg/goversion"
-	"github.com/Masterminds/semver/v3"
 )
 
 func GoVersion(spec *archive.Spec) string {
-	version, _, _ := strings.Cut(spec.Tag, "~")
-	v, err := semver.NewVersion(version)
-	if err != nil {
-		panic(err)
-	}
-
-	if v.Major() < 2 {
-		return goversion.OneTwentyOne
-	} else {
-		return goversion.OneTwentyTwo
-	}
+	return goversion.OneTwentyTwo
 }

--- a/pkg/goversion/version.go
+++ b/pkg/goversion/version.go
@@ -1,7 +1,7 @@
 package goversion
 
 const (
-	DefaultVersion = OneTwentyOne
-	OneTwentyOne   = "1.21.12"
-	OneTwentyTwo   = "1.22.5"
+	DefaultVersion = OneTwentyTwo
+	OneTwentyTwo   = "1.22.8"
+	OneTwentyThree = "1.23.2"
 )


### PR DESCRIPTION
go1.21 is EOL
go1.22 should be able to be used everywhere except compose which requires go1.23.