### PR TITLE
runc: set COMMIT via make arg

### DIFF
--- a/packages/moby-runc/deb.mk
+++ b/packages/moby-runc/deb.mk
@@ -2,7 +2,7 @@ deb: runc man/man8
 
 runc:
 	cd src && \
-	$(MAKE) runc BUILDTAGS='seccomp' VERSION="${VERSION}-${REVISION}"
+	$(MAKE) runc BUILDTAGS='seccomp urfave_cli_no_docs' VERSION="${VERSION}-${REVISION}" COMMIT="${COMMIT}"
 
 man/man8:
 	cd src && \

--- a/packages/moby-runc/rpm.mk
+++ b/packages/moby-runc/rpm.mk
@@ -3,7 +3,7 @@ rpm: runc man/man8
 
 runc:
 	cd src && \
-	$(MAKE) runc BUILDTAGS='seccomp' VERSION="${VERSION}-${REVISION}"
+	$(MAKE) runc BUILDTAGS='seccomp urfave_cli_no_docs' VERSION="${VERSION}-${REVISION}" COMMIT="${COMMIT}"
 
 man/man8:
 	cd src && \


### PR DESCRIPTION
The makefile for runc no longer supports setting COMMIT (and some other things) through env var and instead must be set through make args.

Additionally adds `urfave_cli_no_docs` which is added to the base BUILDTAGS in 1.2 but is not set in 1.1.
This just makes it so the build tag is set on both 1.1 and 1.2 instead of relying on the make file for those tags across branches.