### PR TITLE
Bumps to latest 1.23 release version

### DIFF
--- a/pkg/goversion/version.go
+++ b/pkg/goversion/version.go
@@ -2,5 +2,5 @@ package goversion
 
 const (
 	DefaultVersion = OneTwentyThree
-	OneTwentyThree = "1.23.11"
+	OneTwentyThree = "1.23.12"
 )


### PR DESCRIPTION
This is the minimal change to get compose to continue to build. We'll need to bump to 1.24 soon, but for now 1.23 is fine.